### PR TITLE
Adding 'message' class variants to example page.

### DIFF
--- a/example.html
+++ b/example.html
@@ -134,6 +134,39 @@
 	height:80px;
 }</code></pre>
 	
+	<div class="grids">
+		<div class="grid-8">
+			<div class="message warning">
+				This is warning. Please try again.
+			</div>
+		</div>
+		<div class="grid-8">
+			<div class="message error">
+				This is an error. Please try again.
+			</div>
+		</div>
+	</div>
+
+	<div class="grids">
+		<div class="grid-8">
+			<div class="message info">
+				This message contains som information.
+			</div>
+		</div>
+		<div class="grid-8">
+			<div class="message success">
+				This message is a success!
+			</div>
+		</div>
+	</div>
+	<div class="grids">
+		<div class="grid-8">
+			<div class="message">
+				This is simply an empty message
+			</div>
+		</div>
+	</div>
+	
 	<form action="#">
 		
 		<fieldset>


### PR DESCRIPTION
The classes added to the examples page are:
- &lt;div class="message warning"&gt;...&lt;/div&gt;
- &lt;div class="message error"&gt;...&lt;/div&gt;
- &lt;div class="message info"&gt;...&lt;/div&gt;
- &lt;div class="message success"&gt;...&lt;/div&gt;
- &lt;div class="message"&gt;...&lt;/div&gt;
