### PR TITLE
Removed clearfix from .nav

### DIFF
--- a/inuit.css/partials/objects/_nav.scss
+++ b/inuit.css/partials/objects/_nav.scss
@@ -17,7 +17,6 @@
 .nav{
     list-style:none;
     margin-left:0;
-    @extend .cf;
 }
     .nav > li,
         .nav > li > a{


### PR DESCRIPTION
Looks like the list items in .nav are display:inline-block, removing the need for the clearfix on .nav
