### PR TITLE
"Twelfths" grid option

### DIFF
--- a/inuit.css/partials/objects/_grids.scss
+++ b/inuit.css/partials/objects/_grids.scss
@@ -145,8 +145,8 @@
     .four-twelfths   { @extend .one-third; }
     .five-twelfths   { width:41.666% }
     .six-twelfths    { @extend .one-half; }
-    .seven-twelfths  { width:58.333; }
+    .seven-twelfths  { width:58.333%; }
     .eight-twelfths  { @extend .two-thirds; }
     .nine-twelfths   { @extend .three-quarters; }
     .ten-twelfths    { @extend .five-sixths; }
-    .eleven-twelfths { width:91.666; }
+    .eleven-twelfths { width:91.666%; }


### PR DESCRIPTION
Apologies for what looks like a ton of whitespace changes - if you're half as anal as me, you'll understand how annoying it was to have the last character of .eleven-twelfths touching the { - so I shifted them all 1 character forward to re-add the space and maintain the lined up curly braces  :-)
