### PR TITLE
Using ellipsis instead of three full stops 

### DIFF
--- a/your-project.scss
+++ b/your-project.scss
@@ -13,4 +13,4 @@
 @import "vars";
 @import "inuit.css/inuit";
 
-// She’s all yours, cap’n... Begin importing your stuff here.
+// She’s all yours, cap’n… Begin importing your stuff here.


### PR DESCRIPTION
You’re using curly quotes, perhaps an ellipsis is needed to? Though it does look strange in a fixed width font. 

This isn't a serious pull request, just wanted to stir some typographical debate.
