### PR TITLE
Add .DS_Store to ignored files (on master branch)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 .sass-cache/
 # We don’t want to bundle any compiled CSS
 your-project.css


### PR DESCRIPTION
Prevent pollution added by OSX Finder from being committed. 
