### PR TITLE
Prevent Opera from showing the extra space for the pseudo-element content

### DIFF
--- a/inuit.css/partials/generic/_clearfix.scss
+++ b/inuit.css/partials/generic/_clearfix.scss
@@ -10,7 +10,7 @@
     zoom:1;
     &:before,
     &:after{
-        content:"";
+        content:" ";
         display:table;
     }
     &:after{


### PR DESCRIPTION
The use of content:" " (note the space in the content string) avoids an Opera bug that creates space around clearfixed elements if the contenteditable attribute is also present somewhere in the HTML. 
