### PR TITLE
Change typeface defaults

### DIFF
--- a/_vars.scss
+++ b/_vars.scss
@@ -55,7 +55,7 @@ $micro-size:        10!default;
  * Brand stuff
  */
 $brand-color:       #4a8ec2!default;
-$brand-face:        "Helvetica Neue", sans-serif!default;
+$brand-face:        "Lucida Grande", "Lucida Sans", Tahoma, Ubuntu, sans-serif!default;
 
 
 /**


### PR DESCRIPTION
Helvetica is great for logos and headlines but not for chunk of text on a website. Framework should have defaults that makes sense, no?

Stacking to to:
- **Lucida Grande** - works on Macs and some Windows
- **Lucida Sans** - alternate for Windows
- **Tahoma** - very safe for Windows
- **Ubuntu** - safe for popular Linux distro ubuntu
- **sans-serif** - obvious.
