### PR TITLE
Fixed CSS file to SASS file

### DIFF
--- a/inuit.css/inuit.scss
+++ b/inuit.css/inuit.scss
@@ -7,7 +7,7 @@
  * 
  */
 /**
- * inuit.css acts as a base stylesheet which you should extend with your own
+ * inuit.scss acts as a base stylesheet which you should extend with your own
  * theme stylesheet.
  * 
  * inuit.css aims to do the heavy lifting; sorting objects and abstractions,
@@ -18,8 +18,8 @@
  * take care to read and refer to them as you build. For further support please
  * tweet at @inuitcss.
  * 
- * Owing to the amount of comments please only ever use `inuit.min.css` in
- * production. This file is purely a dev document.
+ * Owing to the amount of comments please only ever use the `--style compressed`
+ * option in the sass command for production. This file is purely a dev document.
  * 
  * The table of contents below maps to section titles of the same name, to jump
  * to any section simply run a find for $[SECTION-TITLE].


### PR DESCRIPTION
In the documentation you have a lot of `inuit.css` refers, but it should be `inuit.scss`. The name of the framework is Inuit.css, so I have only changed the filenames in the documentation and not the framework name.

You should update the INDEX of the `inuit.scss` file too, most of the documentation is moved to other files.
