### PR TITLE
Add compass-inuit reference in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,10 @@ at the [inuit.css Trello board](https://trello.com/board/inuit-css/50a16487543de
 [Peter Wilson](http://twitter.com/pwcc) is maintaining a LESS port of inuit.css:
 check the [GitHub repo](https://github.com/peterwilsoncc/inuit.css).
 
+## Using Compass?
+
+[Stephen Way](http://github.com/stephenway) is maintaining a Compass port of inuit.css: check the [GitHub repo](https://github.com/stephenway/compass-inuit).
+
 ## Test-drive
 
 If you would like to try inuit.css out before you download anything there is a


### PR DESCRIPTION
@csswizardry I'm pushing up every version and am getting enough users to make it worth my while now, so I would like to formally advertise the option on the readme. Here's the stats so far [https://rubygems.org/gems/compass-inuit](https://rubygems.org/gems/compass-inuit)
I also will be providing more templates for this compass extension in the future, seems to help people get started.
Thanks
