### PR TITLE
Improve floats in CSS (with Sass)

### DIFF
--- a/inuit.css/base/_tables.scss
+++ b/inuit.css/base/_tables.scss
@@ -95,27 +95,27 @@ td{
  */
 .t5     { width: 5% }
 .t10    { width:10% }
-.t12    { width:12.5% }     /* 1/8 */
+.t12    { width:quotient(1, 8)% }     /* 1/8 */
 .t15    { width:15% }
 .t20    { width:20% }
 .t25    { width:25% }       /* 1/4 */
 .t30    { width:30% }
-.t33    { width:33.333% }   /* 1/3 */
+.t33    { width:quotient(1, 3)% }   /* 1/3 */
 .t35    { width:35% }
-.t37    { width:37.5% }     /* 3/8 */
+.t37    { width:quotient(3, 8)% }     /* 3/8 */
 .t40    { width:40% }
 .t45    { width:45% }
 .t50    { width:50% }       /* 1/2 */
 .t55    { width:55% }
 .t60    { width:60% }
-.t62    { width:62.5% }     /* 5/8 */
+.t62    { width:quotient(5, 8)% }     /* 5/8 */
 .t65    { width:65% }
-.t66    { width:66.666% }   /* 2/3 */
+.t66    { width:quotient(2, 3)% }   /* 2/3 */
 .t70    { width:70% }
 .t75    { width:75% }       /* 3/4*/
 .t80    { width:80% }
 .t85    { width:85% }
-.t87    { width:87.5% }     /* 7/8 */
+.t87    { width:quotient(7, 8)% }     /* 7/8 */
 .t90    { width:90% }
 .t95    { width:95% }
 

--- a/inuit.css/generic/_mixins.scss
+++ b/inuit.css/generic/_mixins.scss
@@ -86,6 +86,17 @@
 
 
 /**
+ * Calculate the quotient and multiplicate it with 100
+ *
+    quotient(1, 3);
+ *
+ */
+@function quotient($number, $outof){
+    @return $number / $outof * 100;
+}
+
+
+/**
  * CSS arrows!!! But... before you read on, you might want to grab a coffee...
  * 
  * This mixin creates a CSS arrow on a given element. We can have the arrow

--- a/inuit.css/generic/_pull.scss
+++ b/inuit.css/generic/_pull.scss
@@ -18,8 +18,8 @@
 /**
  * Thirds
  */
-.pull--one-third            { @extend .pull; right:33.333%; }
-.pull--two-thirds           { @extend .pull; right:66.666%; }
+.pull--one-third            { @extend .pull; right:quotient(1, 3)%; }
+.pull--two-thirds           { @extend .pull; right:quotient(2, 3)%; }
 
 
 /**
@@ -42,23 +42,23 @@
 /**
  * Sixths
  */
-  .pull--one-sixth          { @extend .pull; right:16.666%; }
+  .pull--one-sixth          { @extend .pull; right:quotient(1, 6)%; }
   .pull--two-sixths         { @extend .pull--one-third; }
 .pull--three-sixths         { @extend .pull--one-half; }
  .pull--four-sixths         { @extend .pull--two-thirds; }
- .pull--five-sixths         { @extend .pull; right:83.333%; }
+ .pull--five-sixths         { @extend .pull; right:quotient(5, 6)%; }
 
 
 /**
  * Eighths
  */
-   .pull--one-eighth        { @extend .pull; right:12.5%; }
+   .pull--one-eighth        { @extend .pull; right:quotient(1, 8)%; }
    .pull--two-eighths       { @extend .pull--one-quarter; }
- .pull--three-eighths       { @extend .pull; right:37.5%; }
+ .pull--three-eighths       { @extend .pull; right:quotient(3, 8)%; }
   .pull--four-eighths       { @extend .pull--one-half; }
-  .pull--five-eighths       { @extend .pull; right:62.5%; }
+  .pull--five-eighths       { @extend .pull; right:quotient(5, 8)%; }
    .pull--six-eighths       { @extend .pull--three-quarters; }
- .pull--seven-eighths       { @extend .pull; right:87.5%; }
+ .pull--seven-eighths       { @extend .pull; right:quotient(7, 8)%; }
 
 
 /**
@@ -78,14 +78,14 @@
 /**
  * Twelfths
  */
-     .pull--one-twelfth     { @extend .pull; right:8.333%; }
+     .pull--one-twelfth     { @extend .pull; right:quotient(1, 12)%; }
      .pull--two-twelfths    { @extend .pull--one-sixth; }
    .pull--three-twelfths    { @extend .pull--one-quarter; }
     .pull--four-twelfths    { @extend .pull--one-third; }
-    .pull--five-twelfths    { @extend .pull; right:41.666%; }
+    .pull--five-twelfths    { @extend .pull; right:quotient(5, 12)%; }
      .pull--six-twelfths    { @extend .pull--one-half; }
-   .pull--seven-twelfths    { @extend .pull; right:58.333%; }
+   .pull--seven-twelfths    { @extend .pull; right:quotient(7, 12)%; }
    .pull--eight-twelfths    { @extend .pull--two-thirds; }
     .pull--nine-twelfths    { @extend .pull--three-quarters; }
      .pull--ten-twelfths    { @extend .pull--five-sixths; }
-  .pull--eleven-twelfths    { @extend .pull; right:91.666%; }
+  .pull--eleven-twelfths    { @extend .pull; right:quotient(11, 12)%; }

--- a/inuit.css/generic/_push.scss
+++ b/inuit.css/generic/_push.scss
@@ -18,8 +18,8 @@
 /**
  * Thirds
  */
-.push--one-third            { @extend .push; left:33.333%; }
-.push--two-thirds           { @extend .push; left:66.666%; }
+.push--one-third            { @extend .push; left:quotient(1, 3)%; }
+.push--two-thirds           { @extend .push; left:quotient(2, 3)%; }
 
 
 /**
@@ -42,23 +42,23 @@
 /**
  * Sixths
  */
-  .push--one-sixth          { @extend .push; left:16.666%; }
+  .push--one-sixth          { @extend .push; left:quotient(1, 6)%; }
   .push--two-sixths         { @extend .push--one-third; }
 .push--three-sixths         { @extend .push--one-half; }
  .push--four-sixths         { @extend .push--two-thirds; }
- .push--five-sixths         { @extend .push; left:83.333%; }
+ .push--five-sixths         { @extend .push; left:quotient(5, 6)%; }
 
 
 /**
  * Eighths
  */
-   .push--one-eighth        { @extend .push; left:12.5%; }
+   .push--one-eighth        { @extend .push; left:quotient(1, 8)%; }
    .push--two-eighths       { @extend .push--one-quarter; }
- .push--three-eighths       { @extend .push; left:37.5%; }
+ .push--three-eighths       { @extend .push; left:quotient(3, 8)%; }
   .push--four-eighths       { @extend .push--one-half; }
-  .push--five-eighths       { @extend .push; left:62.5%; }
+  .push--five-eighths       { @extend .push; left:quotient(5, 8)%; }
    .push--six-eighths       { @extend .push--three-quarters; }
- .push--seven-eighths       { @extend .push; left:87.5%; }
+ .push--seven-eighths       { @extend .push; left:quotient(7, 8)%; }
 
 
 /**
@@ -78,14 +78,14 @@
 /**
  * Twelfths
  */
-     .push--one-twelfth     { @extend .push; left:8.333%; }
+     .push--one-twelfth     { @extend .push; left:quotient(1, 12)%; }
      .push--two-twelfths    { @extend .push--one-sixth; }
    .push--three-twelfths    { @extend .push--one-quarter; }
     .push--four-twelfths    { @extend .push--one-third; }
-    .push--five-twelfths    { @extend .push; left:41.666%; }
+    .push--five-twelfths    { @extend .push; left:quotient(5, 12)%; }
      .push--six-twelfths    { @extend .push--one-half; }
-   .push--seven-twelfths    { @extend .push; left:58.333%; }
+   .push--seven-twelfths    { @extend .push; left:quotient(7, 12)%; }
    .push--eight-twelfths    { @extend .push--two-thirds; }
     .push--nine-twelfths    { @extend .push--three-quarters; }
      .push--ten-twelfths    { @extend .push--five-sixths; }
-  .push--eleven-twelfths    { @extend .push; left:91.666%; }
+  .push--eleven-twelfths    { @extend .push; left:quotient(11, 12)%; }

--- a/inuit.css/generic/_widths.scss
+++ b/inuit.css/generic/_widths.scss
@@ -22,8 +22,8 @@
 /**
  * Thirds
  */
-.one-third          { width:33.333%; }
-.two-thirds         { width:66.666%; }
+.one-third          { width:quotient(1, 3)%; }
+.two-thirds         { width:quotient(2, 3)%; }
 
 
 /**
@@ -46,23 +46,23 @@
 /**
  * Sixths
  */
-  .one-sixth        { width:16.666%; }
+  .one-sixth        { width:quotient(1, 6)%; }
   .two-sixths       { @extend .one-third; }
 .three-sixths       { @extend .one-half; }
  .four-sixths       { @extend .two-thirds; }
- .five-sixths       { width:83.333%; }
+ .five-sixths       { width:quotient(5, 6)%; }
 
 
 /**
  * Eighths
  */
-  .one-eighth       { width:12.5%; }
+  .one-eighth       { width:quotient(1, 8)%; }
   .two-eighths      { @extend .one-quarter; }
-.three-eighths      { width:37.5%; }
+.three-eighths      { width:quotient(3, 8)%; }
  .four-eighths      { @extend .one-half; }
- .five-eighths      { width:62.5%; }
+ .five-eighths      { width:quotient(5, 8)%; }
   .six-eighths      { @extend .three-quarters; }
-.seven-eighths      { width:87.5%; }
+.seven-eighths      { width:quotient(7, 8)%; }
 
 
 /**
@@ -82,17 +82,17 @@
 /**
  * Twelfths
  */
-   .one-twelfth     { width:8.333%; }
+   .one-twelfth     { width:quotient(1, 12)%; }
    .two-twelfths    { @extend .one-sixth; }
  .three-twelfths    { @extend .one-quarter; }
   .four-twelfths    { @extend .one-third; }
-  .five-twelfths    { width:41.666% }
+  .five-twelfths    { width:quotient(5, 12)% }
    .six-twelfths    { @extend .one-half; }
- .seven-twelfths    { width:58.333%; }
+ .seven-twelfths    { width:quotient(7, 12)%; }
  .eight-twelfths    { @extend .two-thirds; }
   .nine-twelfths    { @extend .three-quarters; }
    .ten-twelfths    { @extend .five-sixths; }
-.eleven-twelfths    { width:91.666%; }
+.eleven-twelfths    { width:quotient(11, 12)%; }
 
 
 /**
@@ -118,8 +118,8 @@
 
     .palm-one-half          { width:50%; }
 
-    .palm-one-third         { width:33.333%; }
-    .palm-two-thirds        { width:66.666%; }
+    .palm-one-third         { width:quotient(1, 3)%; }
+    .palm-two-thirds        { width:quotient(2, 3)%; }
 
       .palm-one-quarter     { width:25%; }
       .palm-two-quarters    { @extend .palm-one-half; }
@@ -130,19 +130,19 @@
     .palm-three-fifths      { width:60%; }
      .palm-four-fifths      { width:80%; }
 
-      .palm-one-sixth       { width:16.666%; }
+      .palm-one-sixth       { width:quotient(1, 6)%; }
       .palm-two-sixths      { @extend .palm-one-third; }
     .palm-three-sixths      { @extend .palm-one-half; }
      .palm-four-sixths      { @extend .palm-two-thirds; }
-     .palm-five-sixths      { width:83.333%; }
+     .palm-five-sixths      { width:quotient(5, 6)%; }
 
-      .palm-one-eighth      { width:12.5%; }
+      .palm-one-eighth      { width:quotient(1, 8)%; }
       .palm-two-eighths     { @extend .palm-one-quarter; }
-    .palm-three-eighths     { width:37.5%; }
+    .palm-three-eighths     { width:quotient(3, 8)%; }
      .palm-four-eighths     { @extend .palm-one-half; }
-     .palm-five-eighths     { width:62.5%; }
+     .palm-five-eighths     { width:quotient(5, 8)%; }
       .palm-six-eighths     { @extend .palm-three-quarters; }
-    .palm-seven-eighths     { width:87.5%; }
+    .palm-seven-eighths     { width:quotient(7, 8)%; }
 
       .palm-one-tenth       { width:10%; }
       .palm-two-tenths      { @extend .palm-one-fifth; }
@@ -154,17 +154,17 @@
     .palm-eight-tenths      { @extend .palm-four-fifths; }
      .palm-nine-tenths      { width:90%; }
 
-       .palm-one-twelfth    { width:8.333%; }
+       .palm-one-twelfth    { width:quotient(1, 12)%; }
        .palm-two-twelfths   { @extend .palm-one-sixth; }
      .palm-three-twelfths   { @extend .palm-one-quarter; }
       .palm-four-twelfths   { @extend .palm-one-third; }
-      .palm-five-twelfths   { width:41.666% }
+      .palm-five-twelfths   { width:quotient(5, 12)% }
        .palm-six-twelfths   { @extend .palm-one-half; }
-     .palm-seven-twelfths   { width:58.333%; }
+     .palm-seven-twelfths   { width:quotient(7, 12)%; }
      .palm-eight-twelfths   { @extend .palm-two-thirds; }
       .palm-nine-twelfths   { @extend .palm-three-quarters; }
        .palm-ten-twelfths   { @extend .palm-five-sixths; }
-    .palm-eleven-twelfths   { width:91.666%; }
+    .palm-eleven-twelfths   { width:quotient(11, 12)%; }
     
 }/* end palm */
 
@@ -174,8 +174,8 @@
 
     .lap-one-half           { width:50%; }
 
-    .lap-one-third          { width:33.333%; }
-    .lap-two-thirds         { width:66.666%; }
+    .lap-one-third          { width:quotient(1, 3)%; }
+    .lap-two-thirds         { width:quotient(2, 3)%; }
 
       .lap-one-quarter      { width:25%; }
       .lap-two-quarters     { @extend .lap-one-half; }
@@ -186,19 +186,19 @@
     .lap-three-fifths       { width:60%; }
      .lap-four-fifths       { width:80%; }
 
-      .lap-one-sixth        { width:16.666%; }
+      .lap-one-sixth        { width:quotient(1, 6)%; }
       .lap-two-sixths       { @extend .lap-one-third; }
     .lap-three-sixths       { @extend .lap-one-half; }
      .lap-four-sixths       { @extend .lap-two-thirds; }
-     .lap-five-sixths       { width:83.333%; }
+     .lap-five-sixths       { width:quotient(5, 6)%; }
 
-      .lap-one-eighth       { width:12.5%; }
+      .lap-one-eighth       { width:quotient(1, 8)%; }
       .lap-two-eighths      { @extend .lap-one-quarter; }
-    .lap-three-eighths      { width:37.5%; }
+    .lap-three-eighths      { width:quotient(3, 8)%; }
      .lap-four-eighths      { @extend .lap-one-half; }
-     .lap-five-eighths      { width:62.5%; }
+     .lap-five-eighths      { width:quotient(5, 8)%; }
       .lap-six-eighths      { @extend .lap-three-quarters; }
-    .lap-seven-eighths      { width:87.5%; }
+    .lap-seven-eighths      { width:quotient(7, 8)%; }
 
       .lap-one-tenth        { width:10%; }
       .lap-two-tenths       { @extend .lap-one-fifth; }
@@ -210,17 +210,17 @@
     .lap-eight-tenths       { @extend .lap-four-fifths; }
      .lap-nine-tenths       { width:90%; }
 
-       .lap-one-twelfth     { width:8.333%; }
+       .lap-one-twelfth     { width:quotient(1, 12)%; }
        .lap-two-twelfths    { @extend .lap-one-sixth; }
      .lap-three-twelfths    { @extend .lap-one-quarter; }
       .lap-four-twelfths    { @extend .lap-one-third; }
-      .lap-five-twelfths    { width:41.666% }
+      .lap-five-twelfths    { width:quotient(5, 12)% }
        .lap-six-twelfths    { @extend .lap-one-half; }
-     .lap-seven-twelfths    { width:58.333%; }
+     .lap-seven-twelfths    { width:quotient(7, 12)%; }
      .lap-eight-twelfths    { @extend .lap-two-thirds; }
       .lap-nine-twelfths    { @extend .lap-three-quarters; }
        .lap-ten-twelfths    { @extend .lap-five-sixths; }
-    .lap-eleven-twelfths    { width:91.666%; }
+    .lap-eleven-twelfths    { width:quotient(11, 12)%; }
     
 }/* end lap */
 
@@ -230,8 +230,8 @@
 
     .portable-one-half          { width:50%; }
 
-    .portable-one-third         { width:33.333%; }
-    .portable-two-thirds        { width:66.666%; }
+    .portable-one-third         { width:quotient(1, 3)%; }
+    .portable-two-thirds        { width:quotient(2, 3)%; }
 
       .portable-one-quarter     { width:25%; }
       .portable-two-quarters    { @extend .portable-one-half; }
@@ -242,19 +242,19 @@
     .portable-three-fifths      { width:60%; }
      .portable-four-fifths      { width:80%; }
 
-      .portable-one-sixth       { width:16.666%; }
+      .portable-one-sixth       { width:quotient(1, 6)%; }
       .portable-two-sixths      { @extend .portable-one-third; }
     .portable-three-sixths      { @extend .portable-one-half; }
      .portable-four-sixths      { @extend .portable-two-thirds; }
-     .portable-five-sixths      { width:83.333%; }
+     .portable-five-sixths      { width:quotient(5, 6)%; }
 
-      .portable-one-eighth      { width:12.5%; }
+      .portable-one-eighth      { width:quotient(1, 8)%; }
       .portable-two-eighths     { @extend .portable-one-quarter; }
-    .portable-three-eighths     { width:37.5%; }
+    .portable-three-eighths     { width:quotient(3, 8)%; }
      .portable-four-eighths     { @extend .portable-one-half; }
-     .portable-five-eighths     { width:62.5%; }
+     .portable-five-eighths     { width:quotient(5, 8)%; }
       .portable-six-eighths     { @extend .portable-three-quarters; }
-    .portable-seven-eighths     { width:87.5%; }
+    .portable-seven-eighths     { width:quotient(7, 8)%; }
 
       .portable-one-tenth       { width:10%; }
       .portable-two-tenths      { @extend .portable-one-fifth; }
@@ -266,17 +266,17 @@
     .portable-eight-tenths      { @extend .portable-four-fifths; }
      .portable-nine-tenths      { width:90%; }
 
-       .portable-one-twelfth    { width:8.333%; }
+       .portable-one-twelfth    { width:quotient(1, 12)%; }
        .portable-two-twelfths   { @extend .portable-one-sixth; }
      .portable-three-twelfths   { @extend .portable-one-quarter; }
       .portable-four-twelfths   { @extend .portable-one-third; }
-      .portable-five-twelfths   { width:41.666% }
+      .portable-five-twelfths   { width:quotient(5, 12)% }
        .portable-six-twelfths   { @extend .portable-one-half; }
-     .portable-seven-twelfths   { width:58.333%; }
+     .portable-seven-twelfths   { width:quotient(7, 12)%; }
      .portable-eight-twelfths   { @extend .portable-two-thirds; }
       .portable-nine-twelfths   { @extend .portable-three-quarters; }
        .portable-ten-twelfths   { @extend .portable-five-sixths; }
-    .portable-eleven-twelfths   { width:91.666%; }
+    .portable-eleven-twelfths   { width:quotient(11, 12)%; }
     
 }/* end portable */
 
@@ -286,8 +286,8 @@
 
     .desk-one-half          { width:50%; }
 
-    .desk-one-third         { width:33.333%; }
-    .desk-two-thirds        { width:66.666%; }
+    .desk-one-third         { width:quotient(1, 3)%; }
+    .desk-two-thirds        { width:quotient(2, 3)%; }
 
       .desk-one-quarter     { width:25%; }
       .desk-two-quarters    { @extend .desk-one-half; }
@@ -298,19 +298,19 @@
     .desk-three-fifths      { width:60%; }
      .desk-four-fifths      { width:80%; }
 
-      .desk-one-sixth       { width:16.666%; }
+      .desk-one-sixth       { width:quotient(1, 6)%; }
       .desk-two-sixths      { @extend .desk-one-third; }
     .desk-three-sixths      { @extend .desk-one-half; }
      .desk-four-sixths      { @extend .desk-two-thirds; }
-     .desk-five-sixths      { width:83.333%; }
+     .desk-five-sixths      { width:quotient(5, 6)%; }
 
-      .desk-one-eighth      { width:12.5%; }
+      .desk-one-eighth      { width:quotient(1, 8)%; }
       .desk-two-eighths     { @extend .desk-one-quarter; }
-    .desk-three-eighths     { width:37.5%; }
+    .desk-three-eighths     { width:quotient(3, 8)%; }
      .desk-four-eighths     { @extend .desk-one-half; }
-     .desk-five-eighths     { width:62.5%; }
+     .desk-five-eighths     { width:quotient(5, 8)%; }
       .desk-six-eighths     { @extend .desk-three-quarters; }
-    .desk-seven-eighths     { width:87.5%; }
+    .desk-seven-eighths     { width:quotient(7, 8)%; }
 
       .desk-one-tenth       { width:10%; }
       .desk-two-tenths      { @extend .desk-one-fifth; }
@@ -322,17 +322,17 @@
     .desk-eight-tenths      { @extend .desk-four-fifths; }
      .desk-nine-tenths      { width:90%; }
 
-       .desk-one-twelfth    { width:8.333%; }
+       .desk-one-twelfth    { width:quotient(1, 12)%; }
        .desk-two-twelfths   { @extend .desk-one-sixth; }
      .desk-three-twelfths   { @extend .desk-one-quarter; }
       .desk-four-twelfths   { @extend .desk-one-third; }
-      .desk-five-twelfths   { width:41.666% }
+      .desk-five-twelfths   { width:quotient(5, 12)% }
        .desk-six-twelfths   { @extend .desk-one-half; }
-     .desk-seven-twelfths   { width:58.333%; }
+     .desk-seven-twelfths   { width:quotient(7, 12)%; }
      .desk-eight-twelfths   { @extend .desk-two-thirds; }
       .desk-nine-twelfths   { @extend .desk-three-quarters; }
        .desk-ten-twelfths   { @extend .desk-five-sixths; }
-    .desk-eleven-twelfths   { width:91.666%; }
+    .desk-eleven-twelfths   { width:quotient(11, 12)%; }
     
 }/* end desk */
 

--- a/inuit.css/objects/_lozenges.scss
+++ b/inuit.css/objects/_lozenges.scss
@@ -20,9 +20,9 @@
      * the same width as the `line-height` set on the `html` element.
      * This allows us to use the `.loz` in almost any `font-size` we wish.
      */
-    min-width:    ($line-height-ratio * 0.666667) * 1em;
-    padding-right:($line-height-ratio * 0.166667) * 1em;
-    padding-left: ($line-height-ratio * 0.166667) * 1em;
+    min-width:    ($line-height-ratio * (2 / 3)) * 1em;
+    padding-right:($line-height-ratio * (1 / 6)) * 1em;
+    padding-left: ($line-height-ratio * (1 / 6)) * 1em;
               /* =1.50em */
     text-align:center;
     background-color:#ccc; /* Override this color in your theme stylesheet */

--- a/inuit.css/objects/_matrix.scss
+++ b/inuit.css/objects/_matrix.scss
@@ -80,7 +80,7 @@
         width:50%;
     }
     .three-cols > li{
-        width:33.333%;
+        width:quotient(1, 3)%;
     }
     .four-cols > li{
         width:25%;


### PR DESCRIPTION
Floats are now rounded to 4 decimals, but Sass can be far more precisely. You can set the precision with the `--precision` option in Sass (it defaults to 4). To me, it looks more dev-friendly to let them choose which precision they want and if they don't know the precision it defaults to 4, which is the current standard in inuit.css.

This PR creates a `quotient` function. It returns which part of the 100 you want (`quotient(1, 2) returns`1 / 2 \* 100 = 50`). I have replaced every 4 float to a division and most of them to the`quotient` function, to easy the work and make it more flexible. It helps the readability too :)

I have doubted about the function name. Sass recommends to prefix it with a vendor:

> It is recommended that you prefix your functions to avoid naming conflicts and so that readers of your stylesheets know they are not part of Sass or CSS.
> - [source](http://sass-lang.com/docs/yardoc/file.SASS_REFERENCE.html#function_directives)

If I prefix it with `inuitcss`, the functionname would become very long, but I couldn't found a better vendor, so I removed the vendor completely. What are your thoughts on this?
