### PR TITLE
media query friendly text-cols 

### DIFF
--- a/inuit.css/objects/_columns.scss
+++ b/inuit.css/objects/_columns.scss
@@ -9,10 +9,18 @@
  * Demo: jsfiddle.net/inuitcss/E26Yd
  * 
  */
-%text-cols{
+%text-cols {
     @include vendor(column-gap, $base-spacing-unit);
 }
-.text-cols--2    { @extend %text-cols; @include vendor(column-count, 2); }
-.text-cols--3    { @extend %text-cols; @include vendor(column-count, 3); }
-.text-cols--4    { @extend %text-cols; @include vendor(column-count, 4); }
-.text-cols--5    { @extend %text-cols; @include vendor(column-count, 5); }
+
+@mixin text-cols--2    { @extend %text-cols; @include vendor(column-count, 2); }
+      .text-cols--2    { @include text-cols--2; }
+
+@mixin text-cols--3    { @extend %text-cols; @include vendor(column-count, 3); }
+      .text-cols--3    { @include text-cols--3; }
+
+@mixin text-cols--4    { @extend %text-cols; @include vendor(column-count, 4); }
+      .text-cols--4    { @include text-cols--4; }
+
+@mixin text-cols--5    { @extend %text-cols; @include vendor(column-count, 5); }
+      .text-cols--5    { @include text-cols--5; }


### PR DESCRIPTION
It has been the case (at least in projects I'm working on) where certain media queries require a different number of css text columns. Unfortunately, I can't `@extend` the current configuration from within a media query.

Something like this would fail:

```
 @media screen and (max-width:800px) {
    .foo {
      @extend .text-cols--2;
    }
 }
```

I've abstracted the extension so that an accompanying mixin will work like so:

```
 @media screen and (max-width:800px) {
    .foo {
      @include text-cols--2;
    }
 }
```

This makes consistency more maintainable, since I will no longer have to manually copy and paste any part of the framework directly into my project's Sass files.. 

(Hope it doesn't break any rules of the inuit.css framework!)
