### PR TITLE
Use only necessary vendor prefixes

### DIFF
--- a/inuit.css/generic/_mixins.scss
+++ b/inuit.css/generic/_mixins.scss
@@ -20,15 +20,14 @@
 /**
  * Create vendor-prefixed CSS in one go, e.g.
  * 
-   `@include vendor(border-radius, 4px);`
+   `@include vendor((-webkit-, -moz-), box-sizing, border-box);`
  * 
  */
-@mixin vendor($property, $value...){
-    -webkit-#{$property}:$value;
-       -moz-#{$property}:$value;
-        -ms-#{$property}:$value;
-         -o-#{$property}:$value;
-            #{$property}:$value;
+@mixin vendor($prefixes, $property, $value...){
+    @each $prefix in $prefixes {
+        #{$prefix}#{$property}: #{$value};
+    }
+    #{$property}:$value;
 }
 
 
@@ -36,7 +35,7 @@
  * Create CSS keyframe animations for all vendors in one go, e.g.:
  * 
    .foo{
-       @include vendor(animation, shrink 3s);
+       @include vendor((-webkit-), animation, shrink 3s);
    }
    
    @include keyframe(shrink){

--- a/inuit.css/generic/_reset.scss
+++ b/inuit.css/generic/_reset.scss
@@ -14,7 +14,7 @@
         &,
         &:before,
         &:after{
-            @include vendor(box-sizing, border-box);
+            @include vendor((-webkit-, -moz-), box-sizing, border-box);
         }
     }
 }

--- a/inuit.css/objects/_columns.scss
+++ b/inuit.css/objects/_columns.scss
@@ -10,9 +10,9 @@
  * 
  */
 %text-cols{
-    @include vendor(column-gap, $base-spacing-unit);
+    @include vendor((-webkit-, -moz-), column-gap, $base-spacing-unit);
 }
-.text-cols--2    { @extend %text-cols; @include vendor(column-count, 2); }
-.text-cols--3    { @extend %text-cols; @include vendor(column-count, 3); }
-.text-cols--4    { @extend %text-cols; @include vendor(column-count, 4); }
-.text-cols--5    { @extend %text-cols; @include vendor(column-count, 5); }
+.text-cols--2    { @extend %text-cols; @include vendor((-webkit-, -moz-), column-count, 2); }
+.text-cols--3    { @extend %text-cols; @include vendor((-webkit-, -moz-), column-count, 3); }
+.text-cols--4    { @extend %text-cols; @include vendor((-webkit-, -moz-), column-count, 4); }
+.text-cols--5    { @extend %text-cols; @include vendor((-webkit-, -moz-), column-count, 5); }

--- a/inuit.css/objects/_grids.scss
+++ b/inuit.css/objects/_grids.scss
@@ -94,6 +94,6 @@
         float:left;
         padding-left:$base-spacing-unit;
         @if $global-border-box == false{
-            @include vendor(box-sizing, border-box);
+            @include vendor((-webkit-, -moz-), box-sizing, border-box);
         }
     }

--- a/inuit.css/objects/_matrix.scss
+++ b/inuit.css/objects/_matrix.scss
@@ -37,7 +37,7 @@
         border-right-width: 1px;
         border-bottom-width:1px;
         @if $global-border-box == false{
-            @include vendor(box-sizing, border-box);
+            @include vendor((-webkit-, -moz-), box-sizing, border-box);
         }
     }
 }

--- a/inuit.css/objects/_stats.scss
+++ b/inuit.css/objects/_stats.scss
@@ -35,14 +35,14 @@
         display:-webkit-flex;
         display:   -moz-flex;
         display:        flex;
-        @include vendor(flex-direction, column);
+        @include vendor((-ms-, -webkit-, -moz-), flex-direction, column);
     }
         .stat__title{
-            @include vendor(order, 2);
             -ms-flex-order:2;
+            @include vendor((-webkit-, -moz-), order, 2);
         }
         .stat__value{
             margin-left:0;
-            @include vendor(order, 1);
             -ms-flex-order:1;
+            @include vendor((-webkit-, -moz-), order, 1);
         }


### PR DESCRIPTION
More and more CSS3 features is being unprefixed. I think it's good idea to get rid of one global mixin applying all vendor prefixes and use bunch of more specific mixins addressing each property instead.
