### PR TITLE
Remove whitespace caused by `inline-block`

### DIFF
--- a/inuit.css/objects/_nav.scss
+++ b/inuit.css/objects/_nav.scss
@@ -73,21 +73,28 @@
 
 
 /**
- * Give nav links a big, blocky hit area. Extends `.nav` and needs whitespace
- * caused by `inline-block` elements collapsing e.g.:
+ * Give nav links a big, blocky hit area. Extends `.nav`, e.g.:
  * 
    <ul class="nav  nav--block">
-       <li><a href=#>Home</a></li><!--
-    --><li><a href=#>About</a></li><!--
-    --><li><a href=#>Portfolio</a></li><!--
-    --><li><a href=#>Contact</a></li>
+       <li><a href=#>Home</a></li>
+       <li><a href=#>About</a></li>
+       <li><a href=#>Portfolio</a></li>
+       <li><a href=#>Contact</a></li>
    </ul>
  * 
  */
 .nav--block{
     line-height:1;
+    /**
+     * Remove whitespace caused by `inline-block`.
+     */
+    letter-spacing:-0.31em;
+    word-spacing:-0.43em;
+    white-space:nowrap;
     
     > li{
+        letter-spacing:normal;
+        word-spacing:normal;
         
         > a{
             padding:$half-spacing-unit;

--- a/inuit.css/objects/_options.scss
+++ b/inuit.css/objects/_options.scss
@@ -7,10 +7,10 @@
  * in your theme stylesheet.
  * 
   <ul class="nav  options">
-      <li><a></a></li><!-- 
-   --><li><a></a></li><!-- 
-   --><li><a></a></li><!-- 
-   --><li><a></a></li> 
+      <li><a></a></li>
+      <li><a></a></li>
+      <li><a></a></li>
+      <li><a></a></li>
    </ul>
  * 
  * Demo: jsfiddle.net/inuitcss/vwfaf

--- a/inuit.css/objects/_pagination.scss
+++ b/inuit.css/objects/_pagination.scss
@@ -7,15 +7,15 @@
  * `display:inline-block;` rules.
  * 
    <ol class="nav  pagination">
-       <li class=pagination__first>First</li><!--
-    --><li class=pagination__prev>Previous</li><!--
-    --><li><a href=/page/1>1</a></li><!--
-    --><li><a href=/page/2>2</a></li><!--
-    --><li class=current><a href=/page/3>3</a></li><!--
-    --><li><a href=/page/4>4</a></li><!--
-    --><li><a href=/page/5>5</a></li><!--
-    --><li class=pagination__next><a href=/page/next>Next</a></li><!--
-    --><li class=pagination__last><a href=/page/last>Last</a></li>
+       <li class=pagination__first>First</li>
+       <li class=pagination__prev>Previous</li>
+       <li><a href=/page/1>1</a></li>
+       <li><a href=/page/2>2</a></li>
+       <li class=current><a href=/page/3>3</a></li>
+       <li><a href=/page/4>4</a></li>
+       <li><a href=/page/5>5</a></li>
+       <li class=pagination__next><a href=/page/next>Next</a></li>
+       <li class=pagination__last><a href=/page/last>Last</a></li>
    </ol>
  * 
  * Demo: jsfiddle.net/inuitcss/9Y6PU
@@ -23,9 +23,16 @@
  */
 .pagination{
     text-align:center;
+    /**
+     * Remove whitespace caused by `inline-block`.
+     */
+    letter-spacing:-0.31em;
+    word-spacing:-0.43em;
 }
     .pagination > li{
         padding:$base-spacing-unit / 2;
+        letter-spacing:normal;
+        word-spacing:normal;
     }
         .pagination > li > a{
             padding:$base-spacing-unit / 2;


### PR DESCRIPTION
A more convenient way of removing the whitespace caused by `display: inline-block`. Tested in Chromium 26 and IE8-9. Sorry if the commit looks a bit messy. Ironically my editor removed some whitespace.

http://jsfiddle.net/Qz3a9/
