### PR TITLE
Improve `border-radius` on `options` object

### DIFF
--- a/inuit.css/objects/_options.scss
+++ b/inuit.css/objects/_options.scss
@@ -25,15 +25,25 @@
             border:0 solid #ccc; /* Extend in your theme stylesheet */
             border-width:1px;
             border-left-width:0;
+            border-radius:$brand-round;
         }
 
         &:first-child > a{
             border-left-width:1px;
-            border-radius:$brand-round 0 0 $brand-round;
         }
+    }
 
-        &:last-child > a{
-            border-radius:0 $brand-round $brand-round 0;
-        }
+    > li:not(:first-child):not(:last-child) > a{
+        border-radius:0;
+    }
+
+    > li:first-child > a{
+        border-top-right-radius:0;
+        border-bottom-right-radius:0;
+    }
+
+    > li:last-child > a{
+        border-top-left-radius:0;
+        border-bottom-left-radius:0;
     }
 }


### PR DESCRIPTION
This lets the user define another `border-radius` value easier if they don't want to use `$brand-round` without having to target `:first-child` and `:last-child`. For example:

``` scss
// Old method
.options > li:first-child > a {
  border-radius: 6px 0 0 6px;
}
.options > li:last-child > a {
  border-radius: 0 6px 6px 0;
}

// New method
.options > li > a {
  border-radius: 6px;
}
```
