### PR TITLE
Shorter clearfix for IE8 and above

### DIFF
--- a/inuit.css/generic/_clearfix.scss
+++ b/inuit.css/generic/_clearfix.scss
@@ -2,20 +2,14 @@
     $CLEARFIX
 \*------------------------------------*/
 /**
- * Micro clearfix, as per: nicolasgallagher.com/micro-clearfix-hack
+ * Micro clearfix, as per: css-101.org/articles/clearfix/latest-new-clearfix-so-far.php
  * Extend the clearfix class with Sass to avoid the `.cf` class appearing over
  * and over in your markup.
  */
 .cf{
-    zoom:1;
-    
-    &:before,
     &:after{
-        content:" ";
+        content:"";
         display:table;
-    }
-    
-    &:after{
         clear:both;
     }
 }


### PR DESCRIPTION
Since inuit.css is intended for **IE8** and above only we can minimize the clearfix class.

More information: http://www.css-101.org/articles/clearfix/latest-new-clearfix-so-far.php
- remove z-index: 1 (for IE6/7 hasLayout)
- remove unnecessary :before
