### PR TITLE
nav: remove unnecessary clearfix

### DIFF
--- a/inuit.css/objects/_nav.scss
+++ b/inuit.css/objects/_nav.scss
@@ -19,7 +19,6 @@
 .nav{
     list-style:none;
     margin-left:0;
-    @extend .cf;
 
     > li{
 


### PR DESCRIPTION
As .nav uses inline-block instead of floats clearfix is redundant.

Test:
http://dabblet.com/gist/4739042
