### PR TITLE
Update clearfix to use overflow: auto

### DIFF
--- a/inuit.css/generic/_clearfix.scss
+++ b/inuit.css/generic/_clearfix.scss
@@ -2,14 +2,10 @@
     $CLEARFIX
 \*------------------------------------*/
 /**
- * Micro clearfix, as per: css-101.org/articles/clearfix/latest-new-clearfix-so-far.php
+ * Micro clearfix, as per: http://www.stubbornella.org/content/2009/07/23/overflow-a-secret-benefit/
  * Extend the clearfix class with Sass to avoid the `.cf` class appearing over
  * and over in your markup.
  */
-.cf{
-    &:after{
-        content:"";
-        display:table;
-        clear:both;
-    }
+.cf {
+    overflow: auto;
 }


### PR DESCRIPTION
Clearing floats with overflow: auto works since IE7+.

Simple test: http://jsbin.com/odirez

Tested with Sauce App’s VMs and works on:

IE: 7, 8, 9, 10
Firefox: 3+
Safari: 5+
iOS: 4.3+
Opera: 9+
Chrome

Inspired by Nicole Sullivan’s wonderful article: http://www.stubbornella.org/content/2009/07/23/overflow-a-secret-benefit/
