### PR TITLE
Add component.json

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,0 +1,5 @@
+{
+    "name": "inuit.css",
+    "version": "5.0.0",
+    "dependencies": {}
+}


### PR DESCRIPTION
Since 5.0 introduces better support for using inuit.css as a submodule/package I think we should include a component.json which is used by Bower.

We've touched on this issue before in #28 but support for using inuit.css as a package is better now like I said.

I've also [created](https://github.com/kevva/generator-inuit) a yeoman generator for inuit.css, as an alternative for your web template, which sets up a project with inuit.css installed as a Bower component.
