### PR TITLE
Renamed icon modifiers to match new class

### DIFF
--- a/objects/_sprite.scss
+++ b/objects/_sprite.scss
@@ -91,8 +91,8 @@
 /**
  * Icon size modifiers.
  */
-.i--large   { font-size:32px; }
-.i--huge    { font-size:64px; }
-.i--natural { font-size:inherit; }
+.icon--large   { font-size:32px; }
+.icon--huge    { font-size:64px; }
+.icon--natural { font-size:inherit; }
 
 }//endif


### PR DESCRIPTION
Not a fan of changing lib classnames but as the icon class has been renamed from ".i" to ".icon" should the size modifiers not get updated too?
