### PR TITLE
Do not remove outline of beautons

### DIFF
--- a/objects/_beautons.scss
+++ b/objects/_beautons.scss
@@ -76,11 +76,6 @@
     &:hover{
         text-decoration:none;   /* [9] */
     }
-
-    &:active,
-    &:focus{
-        outline:none;
-    }
 }
 
 


### PR DESCRIPTION
While i always remove the outline i consider removing it generally is bad practice because people forget to add own :focus styles.
This is horrible for keyboard usage.

If i see the outline at testing i'm aware that i could use other styles and remove it manually.
