### PR TITLE
Inuit.css "Kitchen Sink" example page

### DIFF
--- a/_includes/kitchen-sink/base/forms.html
+++ b/_includes/kitchen-sink/base/forms.html
@@ -1,0 +1,116 @@
+<h2 class="section-title" id="forms">Forms</h2>
+<h3>Text Inputs</h3>
+<p>Instead of a `[type]` selector for each kind of form input, we just use a class to target any/every one<p/>
+ <input type="text" class="text-input">
+ <input type="email" class="text-input">
+ <input type="password" class="text-input">
+ <h3>Groups of Form Fields</h3>
+ <p>Group sets of form fields in a list with `.form-fields`</p>
+ <ul class="form-fields">
+   <li>
+       <label>test</label>
+       <input />
+   </li>
+   <li>
+       <select id="country">
+           <option>UK</option>
+           <option>US</option>
+           <option>Other</option>
+       </select>
+       <label>test</label>
+   </li>
+   <li>
+       <input />
+       <label>test</label>
+   </li>
+</ul>
+<h3>Labels</h3>
+<p>Define a `.label` class as well as a `label` element. This means we can apply label-like styling to meta-labels for groups of options where a `label` element is not suitable</p>
+<ul class="form-fields">
+   <li>
+       <label>test</label>
+       <input />
+   </li>
+   <li>
+       <span class="label">Select an option below:</span>
+       <ul class="multi-list  four-cols">
+           <li>
+            <label>test</label>
+            <input />
+        </li>
+        <li>
+            <label>test</label>
+            <input />
+        </li>
+        <li>
+            <label>test</label>
+            <input />
+        </li>
+        <li>
+            <label>test</label>
+            <input />
+        </li>
+    </ul>
+</li>
+</ul>
+<h4>Label - Extra Help</h4>
+<p>Extra help text in `label`s</p>
+<ul class="form-fields">
+   <li>
+       <label>Card number <small class="additional">No spaces</small></label>
+       <input />
+   </li>
+</ul>
+<h2 class="section-title">Groups of Checkboxes and Radios</h2>
+<ul class="form-fields">
+
+    <li>
+        <span class="label">How would you like to be contacted?</span>
+
+        <ul class="check-list">
+            <li>
+                <input type="checkbox" id="by-email"> <label for=by-email>By email</label>
+            </li>
+            <li>
+                <input type="checkbox" id="by-post"> <label for=by-post>By post</label>
+            </li>
+            <li>
+                <input type="checkbox" id="by-pigeon"> <label for=by-pigeon>By carrier pigeon</label>
+            </li>
+        </ul>
+
+    </li>
+
+    <li>
+        <span class="label">How often would you like to be contacted?</span>
+
+        <ul class="check-list  multi-list  two-cols">
+            <li>
+                <input type="radio" name=frequency id="weekly"/> <label for=weekly>Weekly</label>
+            </li>
+            <li>
+                <input type="radio" name=frequency id="daily"/> <label for=daily>Daily</label>
+            </li>
+        </ul>
+    </li>
+</ul>
+<h2 class="section-title">Spoken Forms</h2>
+<p>Spoken forms are for forms that read like spoken word</p>
+<ul class="form-fields">
+    <li class="spoken-form">
+       Hello, my <label for=spoken-name>name</label> is
+       <input type="text" class="text-input" id="spoken-name"/>. My home
+       <label for=country>country</label> is
+       <select id="country">
+           <option>UK</option>
+           <option>US</option>
+           <option>Other</option>
+       </select>
+   </li>
+</ul>
+<h2 class="section-title">Focus Help</h2>
+<p>Extra help text displayed after a field when that field is in focus. We leave the help text in the document flow and merely set it to `visibility:hidden;`. This means that it won't interfere with anything once it reappears.</p>
+    <label for=email>Email:</label>
+    <input type="email" class="text-input" id="email">
+    <small class="extra-help">.edu emails only</small>
+    <hr />

--- a/_includes/kitchen-sink/base/typography.html
+++ b/_includes/kitchen-sink/base/typography.html
@@ -1,0 +1,74 @@
+<h2 class="section-title" id="typography">Typography</h2>
+<h3>Headings</h3>
+<p>When we define a heading we also define a corresponding class to go with it.
+This allows us to apply, say, `class="alpha"` to a `h3`; a double-stranded
+heading hierarchy.</p>
+<ol>
+	<li><p class="alpha">h1 - .alpha</p></li>
+	<li><p class="beta">h2 - .beta</p></li>
+	<li><p class="gamma">h3 - .gamma</p></li>
+	<li><p class="delta">h4 - .delta</p></li>
+	<li><p class="epsilon">h5 - .epsilon</p></li>
+	<li><p class="zeta">h6 - .zeta</p></li>
+</ol>
+<hr />
+<h3>Mastheads</h3>
+<ol>
+	<li><p class="giga">.giga</p></li>
+	<li><p class="mega">.mega</p></li>
+	<li><p class="kilo">.kilo</p></li>
+</ol>
+<hr />
+<h3>Small Print</h4>
+<ol>
+	<li><p class="smallprint">.smallprint</p></li>
+	<li><p class="milli">.milli</p></li>
+	<li><p class="micro">.micro</p></li>
+</ol>
+<hr />
+<h3>Paragraphs</h3>
+<h4>Default</h4>
+<p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper.</p>
+<hr />
+<h4>Introductory Text</h4>
+<p>The `.lede` class is used to make the introductory text (usually a paragraph) of a document slightly larger.</p>
+<p class="lead">Senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper.</p>
+<h3>Quotes</h3>
+<hr />
+<h4>Inline quotes</h4>
+<p><q>Pellentesque habitant morbi tristique</q> senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper.</p>
+<hr />
+<h4>Blockquotes</h4>
+<blockquote>
+       <p>Insanity: doing the same thing over and over again and expecting
+       different results.</p>
+       <b class="source">Albert Einstein</b>
+   </blockquote>
+<hr />
+<h3>Lists</h3>
+<h4>Ordered List</h4>
+<ol>
+   <li>Lorem ipsum dolor sit amet, consectetuer adipiscing elit.</li>
+   <li>Aliquam tincidunt mauris eu risus.</li>
+</ol>
+<p>Have a numbered `ul` without the semantics implied by using an `ol`.</p>
+<ul class="numbered-list">
+   <li>Lorem ipsum dolor sit amet, consectetuer adipiscing elit.</li>
+   <li>Aliquam tincidunt mauris eu risus.</li>
+</ul>
+<hr />
+<h4>Unordered List</h4>
+<ul>
+   <li>Lorem ipsum dolor sit amet, consectetuer adipiscing elit.</li>
+   <li>Aliquam tincidunt mauris eu risus.</li>
+</ul>
+<hr />
+<h3>Code</h3>
+<pre><code>
+#header h1 a {
+	display: block;
+	width: 300px;
+	height: 80px;
+}
+</code></pre>
+<hr />

--- a/_includes/kitchen-sink/generic/helper.html
+++ b/_includes/kitchen-sink/generic/helper.html
@@ -1,0 +1,187 @@
+<h2 class="section-title" id="helper">Helper</h2>
+<p>A series of helper classes to use arbitrarily. Only use a helper class if an element/component doesn’t already have a class to which you could apply this styling, e.g. if you need to float `.main-nav` left then add `float:left;` to that ruleset as opposed to adding the `.float--left` class to the markup.</p>
+<p>A lot of these classes carry `!important` as you will always want them to win out over other selectors.</p>
+
+<h3>Add/remove Floats</h3>
+<p class="float--none float-demo greybox">Float none</p>
+<p class="float--right float-demo greybox">Float right</p>
+<p class="float--left float-demo greybox">Float left</p>
+<hr />
+
+<h3>Text aligment</h3>
+<p class="text--left">Text left</p>
+<p class="text--center">Text center</p>
+<p class="text--right">Text right</p>
+<hr />
+
+<h3>Font weights</h3>
+<p class="weight--light">Weight light</p>
+<p class="weight--normal">Weight normal</p>
+<p class="weight--semibold">Weight semibold</p>
+<hr />
+
+<h3>Add/Remove margins</h3>
+<h4>Add Full Margins</h4>
+<p>Adds `$base-spacing-unit` margins</p>
+<ul>
+	<li>.push</li>
+	<li>.push--top</li>
+	<li>.push--right</li>
+	<li>.push--bottom</li>
+	<li>.push--left</li>
+	<li>.push--ends</li>
+	<li>.push--sides</li>
+</ul>
+<div class="margins-demo">
+	<div class="margins-demo__item push--left">Push Left</div>
+</div>
+<div class="margins-demo">
+	<div class="margins-demo__item push--sides">Push Sides</div>
+</div>
+<hr />
+
+<h4>Add Half Margins</h4>
+<p>Adds `$half-spacing-unit` margins</p>
+<ul>
+	<li>.push-half</li>
+	<li>.push-half--top</li>
+	<li>.push-half--right</li>
+	<li>.push-half--bottom</li>
+	<li>.push-half--left</li>
+	<li>.push-half--ends</li>
+	<li>.push-half--sides</li>
+</ul>
+<div class="margins-demo">
+	<div class="margins-demo__item push-half--left">Push Half Left</div>
+</div>
+<div class="margins-demo">
+	<div class="margins-demo__item push-half--sides">Push Half Sides</div>
+</div>
+<hr />
+
+<h4>Remove Margins</h4>
+<p>Takes away margins</p>
+<ul>
+	<li>.flush</li>
+	<li>.flush--top</li>
+	<li>.flush--right</li>
+	<li>.flush--bottom</li>
+	<li>.flush--left</li>
+	<li>.flush--ends</li>
+	<li>.flush--sides</li>
+</ul>
+<div class="margins-demo">
+	<div class="margins-demo__item  margins-demo--full-margin flush--left">Flush Left</div>
+</div>
+<div class="margins-demo">
+	<div class="margins-demo__item margins-demo--full-margin flush--sides">Flush Sides</div>
+</div>
+<hr />
+
+<h3>Add/Remove paddings</h3>
+<h4>Add Full Paddings</h4>
+<p>Adds `$base-spacing-unit` paddings</p>
+<ul>
+	<li>.soft</li>
+	<li>.soft--top</li>
+	<li>.soft--right</li>
+	<li>.soft--bottom</li>
+	<li>.soft--left</li>
+	<li>.soft--ends</li>
+	<li>.soft--sides</li>
+</ul>
+<div class="paddings-demo">
+	<div class="paddings-demo__item soft--left">Soft Left</div>
+</div>
+<div class="paddings-demo">
+	<div class="paddings-demo__item soft--sides">Soft Sides</div>
+</div>
+<hr />
+
+<h4>Add Half Padding</h4>
+<p>Adds `$half-spacing-unit` padding</p>
+<ul>
+	<li>.soft-half</li>
+	<li>.soft-half--top</li>
+	<li>.soft-half--right</li>
+	<li>.soft-half--bottom</li>
+	<li>.soft-half--left</li>
+	<li>.soft-half--ends</li>
+	<li>.soft-half--sides</li>
+</ul>
+<div class="paddings-demo">
+	<div class="paddings-demo__item soft-half--left">Soft Half Left</div>
+</div>
+<div class="paddings-demo">
+	<div class="paddings-demo__item soft-half--sides">Soft Half Sides</div>
+</div>
+<hr />
+
+<h4>Remove Padding</h4>
+<p>Takes away padding</p>
+<ul>
+	<li>.hard</li>
+	<li>.hard--top</li>
+	<li>.hard--right</li>
+	<li>.hard--bottom</li>
+	<li>.hard--left</li>
+	<li>.hard--ends</li>
+	<li>.hard--sides</li>
+</ul>
+<div class="paddings-demo">
+	<div class="paddings-demo__item  paddings-demo--full-padding hard--left">Hard Left</div>
+</div>
+<div class="paddings-demo">
+	<div class="paddings-demo__item paddings-demo--full-padding hard--sides">Hard Sides</div>
+</div>
+<hr />
+
+<h3>Full bleed</h3>
+<div class="island greybox">
+	<p class="full-bleed bleed-demo">Pull items full width of `.island` parents.<p>
+</div>
+<div class="islet greybox">
+	<p class="full-bleed bleed-demo">Pull items full width of `.islet` parents.<p>
+</div>
+<hr />
+
+<h3>Informative</h3>
+<p>Add a help cursor to any element that gives the user extra information on `:hover`.</p>
+<a class="btn btn-demo informative">Help?</a> (Hover me)
+<hr />
+
+<h3>Muted</h3>
+<p>Mute an object by reducing its opacity.</p>
+<a class="btn btn--positive">Without `.muted`</a>
+<a class="btn btn--positive muted">With `.muted`</a>
+<hr />
+
+<h3>Go</h3>
+<p>Add a right-angled quote to links that imply movement</p>
+<a href="#" class="go">Read more</a>
+<hr />
+
+<h3>Caps</h3>
+<p>Apply capital case to an element (usually a `strong`).</p>
+<p class="caps">CAPITALIZE</p>
+<hr />
+
+<h3>Accessibility</h3>
+<p>Hide content off-screen without resorting to `display:none;`, also provide breakpoint specific hidden elements. Classes include:</p>
+<ul>
+	<li>.accessibility</li>
+	<li>.visuallyhidden</li>
+	<li>.accessibility--palm</li>
+	<li>.visuallyhidden--palm</li>
+	<li>.accessibility--lap</li>
+	<li>.visuallyhidden--lap</li>
+	<li>.accessibility--lap-and-up</li>
+	<li>.visuallyhidden--lap-and-up</li>
+	<li>.accessibility--portable</li>
+	<li>.visuallyhidden--portable</li>
+	<li>.accessibility--desk</li>
+	<li>.visuallyhidden--desk</li>
+	<li>.accessibility--desk-wide</li>
+	<li>.visuallyhidden--desk-wide</li>
+</ul>
+

--- a/_includes/kitchen-sink/generic/mixins.html
+++ b/_includes/kitchen-sink/generic/mixins.html
@@ -1,0 +1,86 @@
+<h2 class="section-title" id="mixins">Mixins</h2>
+
+<h3>Typography</h3>
+<h4>Font Size</h4>
+<p>Create a fully formed type style (sizing and vertical rhythm) by passing in a single value.</p>
+<pre><code class="lang-css">@include font-size(10px);
+@include font-size(10px, $line-height: false);</code></pre>
+<h3>Headings</h3>
+<p>Style any number of headings in one fell swoop</p>
+<pre><code>@include headings(1, 3){
+    color:#BADA55;
+}</code></pre>
+<hr />
+
+<h3>CSS3</h3>
+<h4>Vendor</h4>
+<p>Create vendor-prefixed CSS in one go</p>
+<pre><code>@include vendor(border-radius, 4px);</code></pre>
+<h4>Keyframes</h4>
+<p>Create CSS keyframe animations for all vendors in one go</p>
+<pre><code>.foo{
+    @include vendor(animation, shrink 3s);
+}
+
+@include keyframe(shrink){
+    from{
+        font-size:5em;
+    }
+}</code></pre>
+
+<h4>Truncate</h4>
+<p>Force overly long spans of text to truncate</p>
+<pre><code>@include truncate(100%);</code></pre>
+<h4>Retina</h4>
+<p>Media query for targetting retina devices</p>
+<pre><code>.foo{
+    background-image:url(1x.png);
+    @include retina(){
+        background-image:url(2x.png);
+    }
+}</code></pre>
+
+<h3>CSS Arrows</h3>
+<p>This mixin creates a CSS arrow on a given element. We can have the arrow
+appear in one of 12 locations, thus:</p>
+<pre><code>      01    02    03
+   +------------------+
+12 |                  | 04
+   |                  |
+11 |                  | 05
+   |                  |
+10 |                  | 06
+   +------------------+
+      09    08    07</code></pre>
+<p>You pass this position in along with a desired arrow color and optional
+border color, for example:</p>
+<p><code>@include arrow(top, left, red)</code></p>
+<p>for just a single, red arrow, or:</p>
+<p><code>@include arrow(bottom, center, red, black)</code></p>
+<p>which will create a red triangle with a black border which sits at the bottom
+center of the element. Call the mixin thus:</p>
+<pre><code>.foo{
+   background-color:#BADA55;
+   border:1px solid #ACE;
+   @include arrow(top, left, #BADA55, #ACE);
+}</code></pre>
+
+<h4>Media Query Mixin</h4>
+<p>It’s not great practice to define solid breakpoints up-front, preferring to
+modify your design when it needs it, rather than assuming you’ll want a
+change at ‘mobile’. However, as inuit.css is required to take a hands off
+approach to design decisions, this is the closest we can get to baked-in
+responsiveness. It’s flexible enough to allow you to set your own breakpoints
+but solid enough to be frameworkified.</p>
+<p>We define some broad breakpoints in our vars file that are picked up here
+for use in a simple media query mixin. Our options are:</p>
+<ul>
+<li>palm</li>
+<li>lap</li>
+<li>lap-and-up</li>
+<li>portable</li>
+<li>desk</li>
+<li>desk-wide</li>
+</ul>
+<p>Not using a media query will, naturally, serve styles to all devices.</p>
+<p><code>@include media-query(palm){ [styles here] }</code></p>

--- a/_includes/kitchen-sink/objects/arrows.html
+++ b/_includes/kitchen-sink/objects/arrows.html
@@ -1,0 +1,30 @@
+<h2 class="section-title" id="arrows">Arrows</h2>
+<p>It is a common design treatment to give an element a triangular points-out arrow, we typically build these with CSS. These following classes allow us to generate these arbitrarily with a mixin</p>
+
+<h3>Top</h3>
+<pre><code>@include arrow(top, {location}, $color)</code></pre>
+<p class="test-arrow test-arrow--top-left">Left</p>
+<p class="test-arrow test-arrow--top-center">Center</p>
+<p class="test-arrow test-arrow--top-right">Right</p>
+<hr />
+
+<h3>Right</h3>
+<pre><code>@include arrow(right, {location}, $color)</code></pre>
+<p class="test-arrow test-arrow--right-top">Top</p>
+<p class="test-arrow test-arrow--right-center">Center</p>
+<p class="test-arrow test-arrow--right-bottom">Bottom</p>
+<hr />
+
+<h3>Bottom</h3>
+<pre><code>@include arrow(bottom, {location}, $color)</code></pre>
+<p class="test-arrow test-arrow--bottom-left">Left</p>
+<p class="test-arrow test-arrow--bottom-center">Center</p>
+<p class="test-arrow test-arrow--bottom-right">Right</p>
+<hr />
+
+<h3>Left</h3>
+<pre><code>@include arrow(left, {location}, $color)</code></pre>
+<p class="test-arrow test-arrow--left-top">Top</p>
+<p class="test-arrow test-arrow--left-center">Center</p>
+<p class="test-arrow test-arrow--left-bottom">Bottom</p>
+<hr />

--- a/_includes/kitchen-sink/objects/beautons.html
+++ b/_includes/kitchen-sink/objects/beautons.html
@@ -1,0 +1,28 @@
+<h2 class="section-title" id="beautons">Beautons</h2>
+<h3>Button Test Sizes</h3>
+<a class="btn-demo btn">Button</a>
+<a class="btn-demo btn btn--small">Small Button</a>
+<a class="btn-demo btn btn--large">Large Button</a>
+<a class="btn-demo btn btn--huge">Huge Button</a>
+<a class="btn-demo btn btn--full">Full Button</a>
+<hr />
+<h3>Font Sizes</h3>
+<a class="btn-demo btn btn--alpha">Alpha</a>
+<a class="btn-demo btn btn--beta">Beta</a>
+<a class="btn-demo btn btn--gamma">Gamma</a>
+<a class="btn-demo btn btn--natural">Natural</a>
+<hr />
+<h3>Button Functions</h3>
+<a class="btn-demo btn btn--primary">Primary</a>
+<a class="btn-demo btn btn--secondary">Secondary</a>
+<a class="btn-demo btn btn--tertiary">Tertiary</a>
+<hr />
+<h3>Button Actions</h3>
+<a class="btn btn--positive">Positive</a>
+<a class="btn btn--negative">Negative</a>
+<a class="btn btn--inactive">Inactive</a>
+<hr />
+<h3>Button Styles</h3>
+<a class="btn-demo btn btn--soft">Soft</a>
+<a class="btn-demo btn btn--hard">Hard</a>
+<hr />

--- a/_includes/kitchen-sink/objects/block-list.html
+++ b/_includes/kitchen-sink/objects/block-list.html
@@ -1,0 +1,7 @@
+<h2 class="section-title" id="block-list">Block List</h2>
+<ul class="block-list">
+  <li>Foo</li>
+  <li>Bar</li>
+  <li>Baz</li>
+  <li><a href=# class="block-list__link">Foo Bar Baz</a></li>
+</ul>

--- a/_includes/kitchen-sink/objects/breadcrumb.html
+++ b/_includes/kitchen-sink/objects/breadcrumb.html
@@ -1,0 +1,34 @@
+<h2 class="section-title" id="breadcrumb">Breadcrumb</h2>
+<h3>Default</h3>
+<p>Simple breadcrumb styling to apply to (ordered) lists. Extends `.nav`</p>
+<ol class="nav  breadcrumb">
+   <li><a href=#>Home</a></li>
+   <li><a href=#>About</a></li>
+   <li><a href=#>The Board</a></li>
+   <li class="current"><a href=#>Directors</a></li>
+</ol>
+<hr />
+<h3>Path</h3>
+<p>For denoting a path-like structure, GitHub style</p>
+<ol class="nav  breadcrumb--path">
+   <li class="breadcrumb__root"><a href=#>inuit.css</a></li>
+   <li><a href=#>inuit.css</a></li>
+   <li><a href=#>partials</a></li>
+   <li class="current"><a href=#>objects</a></li>
+</ol>
+<hr />
+<h3>Custom</h3>
+<p>Assign a delimiter on the fly through a data attribute</p>
+<ol class="nav  breadcrumb">
+   <li><a href=#>Home</a></li>
+   <li data-breadcrumb="|"><a href=#>About</a></li>
+   <li data-breadcrumb="|"><a href=#>The Board</a></li>
+   <li data-breadcrumb="|" class="current"><a href=#>Directors</a></li>
+</ol>
+<ol class="nav  breadcrumb">
+   <li><a href=#>Home</a></li>
+   <li data-breadcrumb="*"><a href=#>About</a></li>
+   <li data-breadcrumb="*"><a href=#>The Board</a></li>
+   <li data-breadcrumb="*" class="current"><a href=#>Directors</a></li>
+</ol>
+<hr />

--- a/_includes/kitchen-sink/objects/columns.html
+++ b/_includes/kitchen-sink/objects/columns.html
@@ -1,0 +1,7 @@
+<h2 class="section-title" id="columns">Columns</h2>
+<p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.</p>
+
+<p class="text-cols--3">Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.</p>
+
+<p class="text-cols--2">Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.</p>
+<hr />

--- a/_includes/kitchen-sink/objects/flexbox.html
+++ b/_includes/kitchen-sink/objects/flexbox.html
@@ -1,0 +1,26 @@
+<h2 class="section-title" id="flexbox">FlexBox</h2>
+<p>Until we can utilise flexbox natively we can kinda, sorta, attempt to emulate it</p>
+<h3>FlexBox Default</h3>
+<div class="flexbox">
+
+    <div class="flexbox__item flexbox-demo">
+        <b>Welcome to</b>
+    </div>
+
+    <div class="flexbox__item flexbox-demo">
+        <img src="http://placehold.it/600x150" alt="inuit.css logo">
+    </div>
+
+</div>
+<hr />
+
+<h3>FlexBox with Grids</h3>
+<div class="flexbox">
+   <div class="flexbox__item  one-quarter greybox flexbox-demo">
+   		<p>One Quarter</p>
+   </div>
+   <div class="flexbox__item  three-quarters greybox flexbox-demo">
+   		<p>Three Quarters</p>
+   </div>
+</div>
+<hr />

--- a/_includes/kitchen-sink/objects/flyout.html
+++ b/_includes/kitchen-sink/objects/flyout.html
@@ -1,0 +1,20 @@
+<h2 class="section-title" id="flyout">Flyout</h2>
+<p>Flyouts are pieces of content that fly out of a parent when said parent is hovered. They typically appear bottom-left of the parent.</p>
+<h3>Flyout Regular - From the top, flush left</h3>
+<div class="flyout btn-demo btn btn-large">
+       Hover Me
+   <div class="flyout__content greybox">
+       <h1>Lorem</h1>
+       <p>Ipsum</p>
+   </div>
+</div>
+<hr />
+<h3>Flyout Alternative - Left, Flush Top</h3>
+<div class="flyout--alt btn-demo btn btn--large">
+       Hover Me
+   <div class="flyout__content greybox">
+       <h1>Lorem</h1>
+       <p>Ipsum</p>
+   </div>
+</div>
+<hr />

--- a/_includes/kitchen-sink/objects/greybox.html
+++ b/_includes/kitchen-sink/objects/greybox.html
@@ -1,0 +1,17 @@
+<h2 class="section-title" id="greybox">GreyBox - For Prototyping</h2>
+<p>Quickly throw together greybox wireframes. Use in conjunction with other inuit.css objects to create simple greybox prototypes</p>
+<h3>Generic</h3>
+<ul class="nav  nav--fit  nav--block  greybox">
+   <li><a href=#>Home</a></li>
+   <li><a href=#>About</a></li>
+   <li><a href=#>Portfolio</a></li>
+   <li><a href=#>Contact</a></li>
+</ul>
+<hr />
+<h3>Greybox Sizes</h3>
+<div class="island  greybox  greybox--small">Small</div>
+<div class="island  greybox  greybox--medium">Medium</div>
+<div class="island  greybox  greybox--large">Large</div>
+<div class="island  greybox  greybox--huge">Header</div>
+<div class="island  greybox  greybox--gigantic">Gigantic</div>
+<hr />

--- a/_includes/kitchen-sink/objects/grids.html
+++ b/_includes/kitchen-sink/objects/grids.html
@@ -1,0 +1,158 @@
+<h2 class="section-title" id="grids">Grids</h2>
+<p>A fluid and nestable grid system. The grid system is based on <a href="http://github.com/csswizardry/csswizardry-grids">csswizardry-grids</a>. If you would like to use the full features of csswizardry-grids then you can simply use it in conjunction with inuit.css as a second library.</p>
+<p>As <strong>.grid__item</strong>s use <em>display: inline-block</em> it's required to strip whitespace using comments from between them e.g.</p>
+<pre>
+    <code>
+&lt;div class="grid"&gt;
+
+   &lt;div class="grid__item  one-third"&gt;
+       &lt;p&gt;One third grid&lt;/p&gt;
+   &lt;/div&gt;&lt;!--
+
+--&gt;&lt;div class="grid__item  two-thirds"&gt;
+       &lt;p&gt;Two thirds grid&lt;/p&gt;
+   &lt;/div&gt;&lt;!--
+
+--&gt;&lt;div class="grid__item  one-half"&gt;
+       &lt;p&gt;One half grid&lt;/p&gt;
+   &lt;/div&gt;&lt;!--
+
+--&gt;&lt;div class="grid__item  one-quarter"&gt;
+       &lt;p&gt;One quarter grid&lt;/p&gt;
+   &lt;/div&gt;&lt;!--
+
+--&gt;&lt;div class="grid__item  one-quarter"&gt;
+       &lt;p&gt;One quarter grid&lt;/p&gt;
+   &lt;/div&gt;
+
+&lt;/div&gt;
+    </code>
+</pre>
+<h3>Regular</h3>
+<div class="grid">
+
+    <div class="grid__item one-whole">
+        <p class="greybox">1</p>
+    </div><!--
+
+ --><div class="grid__item one-half">
+        <p class="greybox">2</p>
+    </div><!--
+
+ --><div class="grid__item one-quarter">
+        <p class="greybox">3</p>
+    </div><!--
+
+ --><div class="grid__item one-quarter">
+        <p class="greybox">4</p>
+    </div><!--
+
+ --><div class="grid__item one-third">
+        <p class="greybox">5</p>
+    </div><!--
+
+ --><div class="grid__item one-third">
+        <p class="greybox">6</p>
+    </div><!--
+
+ --><div class="grid__item one-third">
+        <p class="greybox">7</p>
+    </div>
+
+</div>
+<h3>Reversed</h3>
+<div class="grid grid--rev">
+
+    <div class="grid__item one-whole">
+        <p class="greybox">1</p>
+    </div><!--
+
+ --><div class="grid__item one-half">
+        <p class="greybox">2</p>
+    </div><!--
+
+ --><div class="grid__item one-quarter">
+        <p class="greybox">3</p>
+    </div><!--
+
+ --><div class="grid__item one-quarter">
+        <p class="greybox">4</p>
+    </div><!--
+
+ --><div class="grid__item one-third">
+        <p class="greybox">5</p>
+    </div><!--
+
+ --><div class="grid__item one-third">
+        <p class="greybox">6</p>
+    </div><!--
+
+ --><div class="grid__item one-third">
+        <p class="greybox">7</p>
+    </div>
+
+</div>
+<h3>Full</h3>
+<div class="grid grid--full">
+
+    <div class="grid__item one-whole">
+        <p class="greybox grid-demo">1</p>
+    </div><!--
+
+ --><div class="grid__item one-half">
+        <p class="greybox grid-demo">2</p>
+    </div><!--
+
+ --><div class="grid__item one-quarter">
+        <p class="greybox grid-demo">3</p>
+    </div><!--
+
+ --><div class="grid__item one-quarter">
+        <p class="greybox grid-demo">4</p>
+    </div><!--
+
+ --><div class="grid__item one-third">
+        <p class="greybox grid-demo">5</p>
+    </div><!--
+
+ --><div class="grid__item one-third">
+        <p class="greybox grid-demo">6</p>
+    </div><!--
+
+ --><div class="grid__item one-third">
+        <p class="greybox grid-demo">7</p>
+    </div>
+
+</div>
+<h3>Center</h3>
+<div class="grid grid--center">
+
+    <div class="grid__item one-whole">
+        <p class="greybox">1</p>
+    </div><!--
+
+ --><div class="grid__item one-half">
+        <p class="greybox">2</p>
+    </div><!--
+
+ --><div class="grid__item one-quarter">
+        <p class="greybox">3</p>
+    </div><!--
+
+ --><div class="grid__item one-quarter">
+        <p class="greybox">4</p>
+    </div><!--
+
+ --><div class="grid__item one-third">
+        <p class="greybox">5</p>
+    </div><!--
+
+ --><div class="grid__item one-third">
+        <p class="greybox">6</p>
+    </div><!--
+
+ --><div class="grid__item one-third">
+        <p class="greybox">7</p>
+    </div>
+
+</div>

--- a/_includes/kitchen-sink/objects/images.html
+++ b/_includes/kitchen-sink/objects/images.html
@@ -1,0 +1,11 @@
+<h2 class="section-title" id="images">Images</h2>
+<p>Non-fluid images if you specify `width` and/or `height` attributes.</p>
+<img src="http://placekitten.com/300/200" alt="" width="300" height="200" />
+<h3>Round Images</h3>
+<img src="http://placekitten.com/300/200" alt="" class="img--short  img--round">
+<h3>Image placement variations</h3>
+<p>`.img--right`, `.img--left` and `.img--center`</p>
+<img src="http://placekitten.com/300/200" alt="" class="img--right  img--short">
+<img src="http://placekitten.com/300/200" alt="" class="img--left  img--medium">
+<p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac dui. Donec non enim in turpis pulvinar facilisis. Ut felis. Praesent dapibus, neque id cursus faucibus, tortor neque egestas augue, eu vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi, tincidunt quis, accumsan porttitor, facilisis luctus, metus.</p>
+<img src="http://placekitten.com/300/200" alt="" class="img--center  img--medium">

--- a/_includes/kitchen-sink/objects/island.html
+++ b/_includes/kitchen-sink/objects/island.html
@@ -1,0 +1,13 @@
+<h2 class="section-title" id="island">Island</h2>
+<p>Simple, boxed off content</p>
+<h3>Island</h3>
+<div class="island greybox">
+	I am boxed off.
+</div>
+<hr />
+<h3>Islet</h3>
+<p>Just like `.island`, only smaller</p>
+<div class="islet greybox">
+	I am boxed off.
+</div>
+<hr />

--- a/_includes/kitchen-sink/objects/link-complex.html
+++ b/_includes/kitchen-sink/objects/link-complex.html
@@ -1,0 +1,6 @@
+<h2 class="section-title" id="link-complex">Link Complex</h2>
+<p>Add hover behaviour to only selected items within links</p>
+<a href=log-in class="link-complex">
+    <strong class="link-complex__target">Log in</strong> to your account.
+</a>
+<hr />

--- a/_includes/kitchen-sink/objects/lozenges.html
+++ b/_includes/kitchen-sink/objects/lozenges.html
@@ -1,0 +1,5 @@
+<h2 class="section-title" id="lozenges">Lozenges</h2>
+<p>Create pill- and lozenge-like runs of text. Pills have fully rounded ends. lozenges have only their corners rounded</p>
+<p>This <span class="pill">here</span> is a pill!</p>
+<p>This <span class="loz">here</span> is also a lozenge!</p>
+<hr />

--- a/_includes/kitchen-sink/objects/marginalia.html
+++ b/_includes/kitchen-sink/objects/marginalia.html
@@ -1,0 +1,9 @@
+<h2 class="section-title" id="marginalia">Marginalia</h2>
+<p>Marginalia are, per definition, notes in the margin of a document. The `marginalia__body` class can be applied to all kinds of content, like text or images, and is joined by a width class</p>
+
+<div class="marginalia">
+    <p class="marginalia__body--right  desk-one-fifth">This is some marginalia content.</p>
+</div>
+
+<p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit</p>
+<hr />

--- a/_includes/kitchen-sink/objects/matrix.html
+++ b/_includes/kitchen-sink/objects/matrix.html
@@ -1,0 +1,10 @@
+<h2 class="section-title" id="matrix">Matrix</h2>
+<p>Create a grid of items out of a single list</p>
+<ul class="matrix  three-cols">
+       <li class="all-cols">Lorem</li>
+       <li>Ipsum <a href=#>dolor</a></li>
+       <li><a href=# class="matrix__link">Sit</a></li>
+       <li>Amet</li>
+       <li class="all-cols">Consectetuer</li>
+   </ul>
+<hr />

--- a/_includes/kitchen-sink/objects/media.html
+++ b/_includes/kitchen-sink/objects/media.html
@@ -1,0 +1,14 @@
+<h2 class="section-title" id="media">Media</h2>
+<p>Place any image- and text-like content side-by-side</p>
+<h3>Regular</h3>
+<div class="media">
+    <img src=http://placekitten.com/96/96 alt="" class="media__img">
+    <p class="media__body">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+</div>
+<hr />
+<h3>Reversed</h2>
+<div class="media">
+    <img src=http://placekitten.com/96/96 alt="" class="media__img--rev">
+    <p class="media__body">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+</div>
+<hr />

--- a/_includes/kitchen-sink/objects/nav.html
+++ b/_includes/kitchen-sink/objects/nav.html
@@ -1,0 +1,55 @@
+<h2 class="section-title" id="nav">Nav</h2>
+<p>Nav abstraction as per: csswizardry.com/2011/09/the-nav-abstraction When used on an `ol` or `ul`, this class throws the list into horizontal mode</p>
+<h3>Default</h3>
+<ul class="nav">
+   <li><a href=#>Home</a></li>
+   <li><a href=#>About</a></li>
+   <li><a href=#>Portfolio</a></li>
+   <li><a href=#>Contact</a></li>
+</ul>
+<hr />
+<h3>Stacked</h3>
+<p>`.nav--stacked` extends `.nav` and throws the list into vertical mode</p>
+<ul class="nav  nav--stacked">
+   <li><a href=#>Home</a></li>
+   <li><a href=#>About</a></li>
+   <li><a href=#>Portfolio</a></li>
+   <li><a href=#>Contact</a></li>
+</ul>
+<hr />
+<h3>Banner</h3>
+<p>`.nav--banner` extends `.nav` and centres the list</p>
+<ul class="nav  nav--banner">
+   <li><a href=#>Home</a></li>
+   <li><a href=#>About</a></li>
+   <li><a href=#>Portfolio</a></li>
+   <li><a href=#>Contact</a></li>
+</ul>
+<hr />
+<h3>Block</h3>
+<p>Give nav links a big, blocky hit area. Extends `.nav`</p>
+<ul class="nav  nav--block">
+   <li><a href=# class="greybox">Home</a></li>
+   <li><a href=# class="greybox">About</a></li>
+   <li><a href=# class="greybox">Portfolio</a></li>
+   <li><a href=# class="greybox">Contact</a></li>
+</ul>
+<hr />
+<h3>Fit</h3>
+<p>Force a nav to occupy 100% of the available width of its parent. Extends `.nav`</p>
+<ul class="nav  nav--fit">
+   <li><a href=# class="greybox">Home</a></li>
+   <li><a href=# class="greybox">About</a></li>
+   <li><a href=# class="greybox">Portfolio</a></li>
+   <li><a href=# class="greybox">Contact</a></li>
+</ul>
+<hr />
+<h3>Keywords</h3>
+<p>Make a list of keywords. Extends `.nav`</p>
+<ul class="nav  nav--keywords">
+   <li><a href=#>Home</a></li>
+   <li><a href=#>About</a></li>
+   <li><a href=#>Portfolio</a></li>
+   <li><a href=#>Contact</a></li>
+</ul>
+<hr />

--- a/_includes/kitchen-sink/objects/options.html
+++ b/_includes/kitchen-sink/objects/options.html
@@ -1,0 +1,8 @@
+<h2 class="section-title" id="options">Options</h2>
+<p>Link-group nav, used for displaying related options. Extends `.nav--block` but could also extend `.nav--fit`. Extend with colours and 'current states' in your theme stylesheet.</p>
+<ul class="nav options">
+   <li><a href=#>Save</a></li>
+   <li><a href=#>Delete</a></li>
+   <li><a href=#>Cancel</a></li>
+</ul>
+<hr />

--- a/_includes/kitchen-sink/objects/pagination.html
+++ b/_includes/kitchen-sink/objects/pagination.html
@@ -1,0 +1,14 @@
+<h2 class="section-title" id="pagination">Pagination</h2>
+<p>Basic pagination object, extends `.nav`. Requires some funky commenting to collapse any white-space caused by the `display:inline-block;` rules.</p>
+<ol class="nav  pagination">
+   <li class="pagination__first">First</li>
+   <li class="pagination__prev">Previous</li>
+   <li><a href=/page/1>1</a></li>
+   <li><a href=/page/2>2</a></li>
+   <li class="current"><a href=/page/3>3</a></li>
+   <li><a href=/page/4>4</a></li>
+   <li><a href=/page/5>5</a></li>
+   <li class="pagination__next"><a href=/page/next>Next</a></li>
+   <li class="pagination__last"><a href=/page/last>Last</a></li>
+</ol>
+<hr />

--- a/_includes/kitchen-sink/objects/rule.html
+++ b/_includes/kitchen-sink/objects/rule.html
@@ -1,0 +1,13 @@
+<h2 class="section-title" id="rule">Rule</h2>
+<p>Horizontal rules, extend `hr`.</p>
+<h3>Default</h3>
+<hr />
+<h3>Dotted</h3>
+<hr class="rule rule--dotted" />
+<h3>Dashed</h3>
+<hr class="rule rule--dashed" />
+<h3>Ornamental Rules</h3>
+<p>Ornamental rules. Places a &sect; over the rule.</p>
+<hr class="rule rule--ornament" />
+<p>Pass in an arbitrary ornament though a data attribute</p>
+<hr class="rule  rule--ornament" data-ornament="!" />

--- a/_includes/kitchen-sink/objects/split.html
+++ b/_includes/kitchen-sink/objects/split.html
@@ -1,0 +1,16 @@
+<h2 class="section-title" id="split">Split</h2>
+<p>Simple split item for creating two elements floated away from one another</p>
+<dl class="split">
+   <dt class="split__title">Burger and fries</dt>
+   <dd>&pound;5.99</dd>
+   <dt class="split__title">Fillet steak</dt>
+   <dd>&pound;19.99</dd>
+   <dt class="split__title">Ice cream</dt>
+   <dd>&pound;2.99</dd>
+</dl>
+<ol class="split  results">
+   <li class="first"><b class="split__title">1st place</b> Bob</li>
+   <li class="second"><b class="split__title">2nd place</b> Lilly</li>
+   <li class="third"><b class="split__title">3rd place</b> Ted</li>
+</ol>​
+<hr />

--- a/_includes/kitchen-sink/objects/stats.html
+++ b/_includes/kitchen-sink/objects/stats.html
@@ -1,0 +1,19 @@
+<h2 class="section-title" id="stats">Stats</h2>
+<p>Simple object to display key-value statistic-like information</p>
+<div class="stat-group">
+    <dl class="stat">
+        <dt class="stat__title">Tweets</dt>
+        <dd class="stat__value">27,740</dd>
+    </dl>
+
+    <dl class="stat">
+        <dt class="stat__title">Following</dt>
+        <dd class="stat__value">11,529</dd>
+    </dl>
+
+    <dl class="stat">
+        <dt class="stat__title">Followers</dt>
+        <dd class="stat__value">12,105</dd>
+    </dl>
+</div>
+<hr />

--- a/_includes/kitchen-sink/objects/tables.html
+++ b/_includes/kitchen-sink/objects/tables.html
@@ -1,0 +1,57 @@
+<h2 class="section-title" id="tables">Tables</h2>
+<p>We have a lot at our disposal for making very complex table construct</p>
+<ul>
+	<li>`.table--bordered` - bordered table</li>
+	<li>`.table--striped` - striped table</li>
+	<li>`.table--data` - make type smaller to read data</li>
+</ul>
+<table class="table--bordered  table--striped  table--data">
+ <colgroup>
+ <col class="t"10>
+ <col class="t"10>
+ <col class="t"10>
+ <col>
+</colgroup>
+<thead>
+ <tr>
+   <th colspan=3>Foo</th>
+   <th>Bar</th>
+ </tr>
+ <tr>
+   <th>Lorem</th>
+   <th>Ipsum</th>
+   <th class="numerical">Dolor</th>
+   <th>Sit</th>
+ </tr>
+</thead>
+<tbody>
+ <tr>
+   <th rowspan=3>Sit</th>
+   <td>Dolor</td>
+   <td class="numerical">03.788</td>
+   <td>Lorem</td>
+ </tr>
+ <tr>
+   <td>Dolor</td>
+   <td class="numerical">32.210</td>
+   <td>Lorem</td>
+ </tr>
+ <tr>
+   <td>Dolor</td>
+   <td class="numerical">47.797</td>
+   <td>Lorem</td>
+ </tr>
+ <tr>
+   <th rowspan=2>Sit</th>
+   <td>Dolor</td>
+   <td class="numerical">09.640</td>
+   <td>Lorem</td>
+ </tr>
+ <tr>
+   <td>Dolor</td>
+   <td class="numerical">12.117</td>
+   <td>Lorem</td>
+ </tr>
+</tbody>
+</table>
+<hr />

--- a/_includes/kitchen-sink/objects/this-or-this.html
+++ b/_includes/kitchen-sink/objects/this-or-this.html
@@ -1,0 +1,14 @@
+<h2 class="section-title" id="this-or-this">This or This</h2>
+<p>Simple options object to provide multiple choices. The `.this-or-this__this` and `.this-or-this__or` objects can be sized using the grid-system classes</p>
+<h1 class="this-or-this">
+   <a href=# class="this-or-this__this  two-fifths">
+       Free
+   </a>
+   <span class="this-or-this__or  one-fifth">
+       or
+   </span>
+   <a href=# class="this-or-this__this  two-fifths">
+       Pro
+   </a>
+</h1>
+<hr />

--- a/_includes/kitchen-sink/subnav.html
+++ b/_includes/kitchen-sink/subnav.html
@@ -1,0 +1,186 @@
+<div class="grid__item lap-and-up-one-quarter subnav">
+
+	<h4>Objects</h4>
+	<ul class="block-list">
+		
+		<li>
+			<a href="#arrows">
+				Arrows
+			</a>
+		</li>
+		
+		<li>
+			<a href="#beautons">
+				Beautons
+			</a>
+		</li>
+		
+		<li>
+			<a href="#block-list">
+				Block List
+			</a>
+		</li>
+		
+		<li>
+			<a href="#columns">
+				Columns
+			</a>
+		</li>
+		
+		<li>
+			<a href="#breadcrumb">
+				Breadcrumb
+			</a>
+		</li>
+		
+		<li>
+			<a href="#flexbox">
+				Flexbox
+			</a>
+		</li>
+		
+		<li>
+			<a href="#flyout">
+				Flyout
+			</a>
+		</li>
+		
+		<li>
+			<a href="#greybox">
+				Greybox
+			</a>
+		</li>
+		
+		<li>
+			<a href="#grids">
+				Grids
+			</a>
+		</li>
+		
+		<li>
+			<a href="#images">
+				Images
+			</a>
+		</li>
+		
+		<li>
+			<a href="#island">
+				Island
+			</a>
+		</li>
+		
+		<li>
+			<a href="#link-complex">
+				Link Complex
+			</a>
+		</li>
+		
+		<li>
+			<a href="#lozenges">
+				Lozenges
+			</a>
+		</li>
+		
+		<li>
+			<a href="#marginalia">
+				Marginalia
+			</a>
+		</li>
+		
+		<li>
+			<a href="#matrix">
+				Matrix
+			</a>
+		</li>
+		
+		<li>
+			<a href="#media">
+				Media
+			</a>
+		</li>
+		
+		<li>
+			<a href="#nav">
+				Nav
+			</a>
+		</li>
+		
+		<li>
+			<a href="#options">
+				Options
+			</a>
+		</li>
+		
+		<li>
+			<a href="#pagination">
+				Pagination
+			</a>
+		</li>
+		
+		<li>
+			<a href="#rule">
+				Rule
+			</a>
+		</li>
+		
+		<li>
+			<a href="#split">
+				Split
+			</a>
+		</li>
+		
+		<li>
+			<a href="#stats">
+				Stats
+			</a>
+		</li>
+		
+		<li>
+			<a href="#tables">
+				Tables
+			</a>
+		</li>
+		
+		<li>
+			<a href="#this-or this">
+				This or This
+			</a>
+		</li>
+		
+	</ul>
+
+	<h4>Base</h4>
+	<ul class="block-list">
+		
+		<li>
+			<a href="#forms">
+				Forms
+			</a>
+		</li>
+		
+		<li>
+			<a href="#typography">
+				Typography
+			</a>
+		</li>
+		
+	</ul>
+
+	<h4>Generics</h4>
+	<ul class="block-list">
+		
+		<li>
+			<a href="#mixins">
+				Mixins
+			</a>
+		</li>
+		
+		<li>
+			<a href="#helper">
+				Helper
+			</a>
+		</li>
+		
+	</ul>
+
+</div>

--- a/css/kitchen-sink.css
+++ b/css/kitchen-sink.css
@@ -1,0 +1,4721 @@
+@charset "UTF-8";
+/*------------------------------------*\
+    STYLE.CSS
+\*------------------------------------*/
+/**
+ *
+ * sass --watch style.scss:style.min.css --style compressed
+ *
+ * Here we pull in some variables, include the inuit.css framework, then add our
+ * project-specific components afterwards.
+ */
+/**
+ * Setup
+ */
+/*------------------------------------*\
+    VARS.SCSS
+\*------------------------------------*/
+/**
+ * Any variables you find set in inuit.cssÔÇÖ `_vars.scss` that you do not wish to
+ * keep, simply redefine here. This means that if inuit.css, for example, sets
+ * your `$base-font-size` at 16px and you wish it to be 14px, simply redeclare
+ * that variable in this file. inuit.css ignores its own variables in favour of
+ * using your own, so you can completely modify how inuit.css works without ever
+ * having to alter the framework itself.
+ */
+/*------------------------------------*\
+    $OBJECTS-AND-ABSTRACTIONS
+\*------------------------------------*/
+/**
+ * All of inuit.cssÔÇÖ objects and abstractions are initially turned off by
+ * default. This means that you start any project with as little as possible,
+ * and introducing objects and abstractions is as simple as switching the
+ * following variables to `true`.
+ */
+/*------------------------------------*\
+    $OVERRIDES
+\*------------------------------------*/
+/**
+ * Place any variables that should override inuit.cssÔÇÖ defaults here.
+ */
+/*------------------------------------*\
+    $CUSTOM
+\*------------------------------------*/
+/**
+ * Place any of your own variables that sit on top of inuit.css here.
+ */
+/*------------------------------------*\
+    INUIT.CSS
+\*------------------------------------*/
+/**
+ *
+ * inuitcss.com -- @inuitcss -- @csswizardry
+ *
+ */
+/**
+ * inuit.css acts as a base stylesheet which you should extend with your own
+ * theme stylesheet.
+ *
+ * inuit.css aims to do the heavy lifting; sorting objects and abstractions,
+ * design patterns and fiddly bits of CSS, whilst leaving as much design as
+ * possible to you. inuit.css is the scaffolding to your decorator.
+ *
+ * This stylesheet is heavily documented and contains lots of comments, please
+ * take care to read and refer to them as you build. For further support please
+ * tweet at @inuitcss.
+ *
+ * Owing to the amount of comments please only ever use minified CSS in
+ * production. This file is purely a dev document.
+ *
+ * The table of contents below maps to section titles of the same name, to jump
+ * to any section simply run a find for $[SECTION-TITLE].
+ *
+ * Most objects and abstractions come with a chunk of markup that you should be
+ * able to paste into any view to quickly see how the CSS works in conjunction
+ * with the correct HTML.
+ *
+ * inuit.css is written to this standard: github.com/csswizardry/CSS-Guidelines
+ *
+ * LICENSE
+ *
+ * Copyright 2013 Harry Roberts
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Thank you for choosing inuit.css. May your web fonts render perfectly.
+ */
+/*------------------------------------*\
+    $CONTENTS
+\*------------------------------------*/
+/**
+ * CONTENTS............YouÔÇÖre reading it!
+ * WARNING.............Here be dragons!
+ * IMPORTS.............Begin importing the sections below
+ *
+ * MIXINS..............Super-simple Sass stuff
+ * NORMALIZE...........normalize.css
+ * RESET...............Set some defaults
+ * CLEARFIX............
+ * SHARED..............Shared declarations
+ *
+ * MAIN................High-level elements like `html`, `body`, etc.
+ * HEADINGS............Double-stranded heading hierarchy
+ * PARAGRAPHS..........
+ * SMALLPRINT..........Smaller text elements like `small`
+ * QUOTES..............
+ * CODE................
+ * LISTS...............
+ * IMAGES..............
+ * TABLES..............
+ * FORMS...............
+ *
+ * GRIDS...............Fluid, proportional and nestable grids
+ * FLEXBOX.............Crudely emulate flexbox
+ * COLUMNS.............CSS3 columns
+ * NAV.................A simple abstraction to put a list in horizontal nav mode
+ * OPTIONS.............Grouped nav items
+ * PAGINATION..........Very stripped back, basic paginator
+ * BREADCRUMB..........Simple breadcrumb trail object
+ * MEDIA...............Media object
+ * MARGINALIA..........Simple marginalia content
+ * ISLAND..............Boxed off content
+ * BLOCK-LIST..........Blocky lists of content
+ * MATRIX..............Gridded lists
+ * SPLIT...............A simple split-in-two object
+ * THIS-OR-THIS........Options object
+ * LINK-COMPLEX........
+ * FLYOUT..............Flyout-on-hover object
+ * ARROWS..............CSS arrows
+ * SPRITE..............Generic spriting element
+ * ICON-TEXT...........Icon and text couplings
+ * BEAUTONS............Use the beautons micro library
+ * LOZENGES............Basic lozenge styles
+ * RULES...............Horizontal rules
+ * STATS...............Simple stats object
+ * GREYBOX.............Wireframing styles
+ *
+ * WIDTHS..............Width classes for use alongside the grid system etc.
+ * PUSH................Push classes for manipulating grids
+ * PULL................Pull classes for manipulating grids
+ * BRAND...............Helper class to apply brand treatment to elements
+ * HELPER..............A series of helper classes to use arbitrarily
+ * DEBUG...............Enable to add visual flags for debugging purposes
+ */
+/*------------------------------------*\
+    $WARNING
+\*------------------------------------*/
+/*
+ * inuit.css, being an OO framework, works in keeping with the open/closed
+ * principle. The variables you set previously are now being used throughout
+ * inuit.css to style everything we need for a base. Any custom styles SHOULD
+ * NOT be added or modified in inuit.css directly, but added via your theme
+ * stylesheet as per the open/closed principle:
+ *
+ * csswizardry.com/2012/06/the-open-closed-principle-applied-to-css
+ *
+ * Try not to edit any CSS beyond this point; if you find you need to do so
+ * it is a failing of the framework so please tweet at @inuitcss.
+ */
+/*------------------------------------*\
+    $IMPORTS
+\*------------------------------------*/
+/**
+ * Generic utility styles etc.
+ */
+/*------------------------------------*\
+    $DEFAULTS
+\*------------------------------------*/
+/**
+ * inuit.cssÔÇÖ default variables. Redefine these in your `_vars.scss` file (found
+ * in the inuit.css-web-template) to override them.
+ */
+/*------------------------------------*\
+    $DEBUG
+\*------------------------------------*/
+/**
+ * Debug mode will visually highlight any potential markup/accessibility quirks
+ * in the browser. Set to `true` or `false`.
+ */
+/*------------------------------------*\
+    $BORDER-BOX
+\*------------------------------------*/
+/**
+ * Do you want all elements to adopt `box-sizing:border-box;` as per
+ * paulirish.com/2012/box-sizing-border-box-ftw ?
+ */
+/*------------------------------------*\
+    $BASE
+\*------------------------------------*/
+/**
+ * Base stuff
+ */
+/**
+ * Base font-family.
+ */
+/**
+ * Default colour for objectsÔÇÖ borders etc.
+ */
+/*------------------------------------*\
+    $RESPONSIVE
+\*------------------------------------*/
+/**
+ * Responsiveness?
+ */
+/**
+ * Responsiveness for widescreen/high resolution desktop monitors and beyond?
+ * Note: `$responsive` variable above must be set to true before enabling this.
+ */
+/**
+ * Responsive push and pull produce a LOT of code, only turn them on if you
+ * definitely need them.
+ */
+/**
+ * Note: `$push` variable above must be set to true before enabling these.
+ */
+/**
+ * Note: `$pull` variable above must be set to true before enabling these.
+ */
+/**
+ * Tell inuit.css when breakpoints start.
+ */
+/*------------------------------------*\
+    $FONT-SIZES
+\*------------------------------------*/
+/**
+ * Font-sizes (in pixels). Refer to relevant sections for their implementations.
+ */
+/*------------------------------------*\
+    $BEAUTONS
+\*------------------------------------*/
+/**
+ * Set the background colors for beauton button functions.
+ */
+/*------------------------------------*\
+    $QUOTES
+\*------------------------------------*/
+/**
+ * English quote marks?
+ */
+/**
+ * If you want English quotes then please do not edit these; theyÔÇÖre only here
+ * because Sass needs them.
+ */
+/**
+ * If you need non-English quotes, please alter the following values accordingly:
+ */
+/*------------------------------------*\
+    $BRAND
+\*------------------------------------*/
+/**
+ * Brand stuff
+ */
+/**
+ * How big would you like round corners to be by default?
+ */
+/*------------------------------------*\
+    $OBJECTS AND ABSTRACTIONS
+\*------------------------------------*/
+/**
+ * Which objects and abstractions would you like to use?
+ */
+/*------------------------------------*\
+    $FRAMEWORK
+\*------------------------------------*/
+/**
+ * inuit.css will work these next ones out for use within the framework.
+ *
+ * Assign our `$base-line-height` to a new spacing var for more transparency.
+ */
+/*------------------------------------*\
+    $MIXINS
+\*------------------------------------*/
+/**
+ * Create a fully formed type style (sizing and vertical rhythm) by passing in a
+ * single value, e.g.:
+ *
+   `@include font-size(10px);`
+ *
+ * Thanks to @redclov3r for the `line-height` Sass:
+ * twitter.com/redclov3r/status/250301539321798657
+ */
+/**
+ * Style any number of headings in one fell swoop, e.g.:
+ *
+   .foo{
+       @include headings(1, 3){
+           color:#BADA55;
+       }
+    }
+ *
+ * With thanks to @lar_zzz, @paranoida, @rowanmanning and ultimately
+ * @thierrylemoulec for refining and improving my initial mixin.
+ */
+/**
+ * Create vendor-prefixed CSS in one go, e.g.
+ *
+   `@include vendor(border-radius, 4px);`
+ *
+ */
+/**
+ * Create CSS keyframe animations for all vendors in one go, e.g.:
+ *
+   .foo{
+       @include vendor(animation, shrink 3s);
+   }
+
+   @include keyframe(shrink){
+       from{
+           font-size:5em;
+       }
+   }
+ *
+ * Courtesy of @integralist: twitter.com/integralist/status/260484115315437569
+ */
+/**
+ * Force overly long spans of text to truncate, e.g.:
+ *
+   `@include truncate(100%);`
+ *
+ * Where `$truncation-boundary` is a united measurement.
+ */
+/**
+ * Media query for targetting retina devices, e.g.:
+ *
+   .foo{
+       background-image:url(1x.png);
+       @include retina(){
+           background-image:url(2x.png);
+       }
+   }
+ *
+ */
+/**
+ * CSS arrows!!! But... before you read on, you might want to grab a coffee...
+ *
+ * This mixin creates a CSS arrow on a given element. We can have the arrow
+ * appear in one of 12 locations, thus:
+ *
+ *       01    02    03
+ *    +------------------+
+ * 12 |                  | 04
+ *    |                  |
+ * 11 |                  | 05
+ *    |                  |
+ * 10 |                  | 06
+ *    +------------------+
+ *       09    08    07
+ *
+ * You pass this position in along with a desired arrow color and optional
+ * border color, for example:
+ *
+ * `@include arrow(top, left, red)`
+ *
+ * for just a single, red arrow, or:
+ *
+ * `@include arrow(bottom, center, red, black)`
+ *
+ * which will create a red triangle with a black border which sits at the bottom
+ * center of the element. Call the mixin thus:
+ *
+   .foo{
+       background-color:#BADA55;
+       border:1px solid #ACE;
+       @include arrow(top, left, #BADA55, #ACE);
+   }
+ *
+ */
+/**
+ * Media query mixin.
+ *
+ * ItÔÇÖs not great practice to define solid breakpoints up-front, preferring to
+ * modify your design when it needs it, rather than assuming youÔÇÖll want a
+ * change at ÔÇÿmobileÔÇÖ. However, as inuit.css is required to take a hands off
+ * approach to design decisions, this is the closest we can get to baked-in
+ * responsiveness. ItÔÇÖs flexible enough to allow you to set your own breakpoints
+ * but solid enough to be frameworkified.
+ *
+ * We define some broad breakpoints in our vars file that are picked up here
+ * for use in a simple media query mixin. Our options are:
+ *
+ * palm
+ * lap
+ * lap-and-up
+ * portable
+ * desk
+ * desk-wide
+ *
+ * Not using a media query will, naturally, serve styles to all devices.
+ *
+ * `@include media-query(palm){ [styles here] }`
+ *
+ * We work out your end points for you:
+ */
+/* normalize.css v2.1.0 | MIT License | git.io/normalize */
+/* ==========================================================================
+   HTML5 display definitions
+   ========================================================================== */
+/*
+ * Correct `block` display not defined in IE 8/9.
+ */
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+main,
+nav,
+section,
+summary {
+  display: block;
+}
+
+/*
+ * Correct `inline-block` display not defined in IE 8/9.
+ */
+audio,
+canvas,
+video {
+  display: inline-block;
+}
+
+/*
+ * Prevent modern browsers from displaying `audio` without controls.
+ * Remove excess height in iOS 5 devices.
+ */
+audio:not([controls]) {
+  display: none;
+  height: 0;
+}
+
+/*
+ * Address styling not present in IE 8/9.
+ */
+[hidden] {
+  display: none;
+}
+
+/* ==========================================================================
+   Base
+   ========================================================================== */
+/*
+ * 1. Set default font family to sans-serif.
+ * 2. Prevent iOS text size adjust after orientation change, without disabling
+ *    user zoom.
+ */
+html {
+  font-family: sans-serif;
+  /* 1 */
+  -webkit-text-size-adjust: 100%;
+  /* 2 */
+  -ms-text-size-adjust: 100%;
+  /* 2 */
+}
+
+/*
+ * Remove default margin.
+ */
+body {
+  margin: 0;
+}
+
+/* ==========================================================================
+   Links
+   ========================================================================== */
+/*
+ * Address `outline` inconsistency between Chrome and other browsers.
+ */
+a:focus {
+  outline: thin dotted;
+}
+
+/*
+ * Improve readability when focused and also mouse hovered in all browsers.
+ */
+a:active,
+a:hover {
+  outline: 0;
+}
+
+/* ==========================================================================
+   Typography
+   ========================================================================== */
+/*
+ * Address variable `h1` font-size and margin within `section` and `article`
+ * contexts in Firefox 4+, Safari 5, and Chrome.
+ */
+h1 {
+  font-size: 2em;
+  margin: 0.67em 0;
+}
+
+/*
+ * Address styling not present in IE 8/9, Safari 5, and Chrome.
+ */
+abbr[title] {
+  border-bottom: 1px dotted;
+}
+
+/*
+ * Address style set to `bolder` in Firefox 4+, Safari 5, and Chrome.
+ */
+b,
+strong {
+  font-weight: bold;
+}
+
+/*
+ * Address styling not present in Safari 5 and Chrome.
+ */
+dfn {
+  font-style: italic;
+}
+
+/*
+ * Address differences between Firefox and other browsers.
+ */
+hr {
+  -moz-box-sizing: content-box;
+  box-sizing: content-box;
+  height: 0;
+}
+
+/*
+ * Address styling not present in IE 8/9.
+ */
+mark {
+  background: #ff0;
+  color: #000;
+}
+
+/*
+ * Correct font family set oddly in Safari 5 and Chrome.
+ */
+code,
+kbd,
+pre,
+samp {
+  font-family: monospace, serif;
+  font-size: 1em;
+}
+
+/*
+ * Improve readability of pre-formatted text in all browsers.
+ */
+pre {
+  white-space: pre-wrap;
+}
+
+/*
+ * Set consistent quote types.
+ */
+q {
+  quotes: "\201C" "\201D" "\2018" "\2019";
+}
+
+/*
+ * Address inconsistent and variable font size in all browsers.
+ */
+small {
+  font-size: 80%;
+}
+
+/*
+ * Prevent `sub` and `sup` affecting `line-height` in all browsers.
+ */
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sup {
+  top: -0.5em;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+/* ==========================================================================
+   Embedded content
+   ========================================================================== */
+/*
+ * Remove border when inside `a` element in IE 8/9.
+ */
+img {
+  border: 0;
+}
+
+/*
+ * Correct overflow displayed oddly in IE 9.
+ */
+svg:not(:root) {
+  overflow: hidden;
+}
+
+/* ==========================================================================
+   Figures
+   ========================================================================== */
+/*
+ * Address margin not present in IE 8/9 and Safari 5.
+ */
+figure {
+  margin: 0;
+}
+
+/* ==========================================================================
+   Forms
+   ========================================================================== */
+/*
+ * Define consistent border, margin, and padding.
+ */
+fieldset {
+  border: 1px solid #c0c0c0;
+  margin: 0 2px;
+  padding: 0.35em 0.625em 0.75em;
+}
+
+/*
+ * 1. Correct `color` not being inherited in IE 8/9.
+ * 2. Remove padding so people aren't caught out if they zero out fieldsets.
+ */
+legend {
+  border: 0;
+  /* 1 */
+  padding: 0;
+  /* 2 */
+}
+
+/*
+ * 1. Correct font family not being inherited in all browsers.
+ * 2. Correct font size not being inherited in all browsers.
+ * 3. Address margins set differently in Firefox 4+, Safari 5, and Chrome.
+ */
+button,
+input,
+select,
+textarea {
+  font-family: inherit;
+  /* 1 */
+  font-size: 100%;
+  /* 2 */
+  margin: 0;
+  /* 3 */
+}
+
+/*
+ * Address Firefox 4+ setting `line-height` on `input` using `!important` in
+ * the UA stylesheet.
+ */
+button,
+input {
+  line-height: normal;
+}
+
+/*
+ * Address inconsistent `text-transform` inheritance for `button` and `select`.
+ * All other form control elements do not inherit `text-transform` values.
+ * Correct `button` style inheritance in Chrome, Safari 5+, and IE 8+.
+ * Correct `select` style inheritance in Firefox 4+ and Opera.
+ */
+button,
+select {
+  text-transform: none;
+}
+
+/*
+ * 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio`
+ *    and `video` controls.
+ * 2. Correct inability to style clickable `input` types in iOS.
+ * 3. Improve usability and consistency of cursor style between image-type
+ *    `input` and others.
+ */
+button,
+html input[type="button"],
+input[type="reset"],
+input[type="submit"] {
+  -webkit-appearance: button;
+  /* 2 */
+  cursor: pointer;
+  /* 3 */
+}
+
+/*
+ * Re-set default cursor for disabled elements.
+ */
+button[disabled],
+html input[disabled] {
+  cursor: default;
+}
+
+/*
+ * 1. Address box sizing set to `content-box` in IE 8/9.
+ * 2. Remove excess padding in IE 8/9.
+ */
+input[type="checkbox"],
+input[type="radio"] {
+  box-sizing: border-box;
+  /* 1 */
+  padding: 0;
+  /* 2 */
+}
+
+/*
+ * 1. Address `appearance` set to `searchfield` in Safari 5 and Chrome.
+ * 2. Address `box-sizing` set to `border-box` in Safari 5 and Chrome
+ *    (include `-moz` to future-proof).
+ */
+input[type="search"] {
+  -webkit-appearance: textfield;
+  /* 1 */
+  -moz-box-sizing: content-box;
+  -webkit-box-sizing: content-box;
+  /* 2 */
+  box-sizing: content-box;
+}
+
+/*
+ * Remove inner padding and search cancel button in Safari 5 and Chrome
+ * on OS X.
+ */
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+/*
+ * Remove inner padding and border in Firefox 4+.
+ */
+button::-moz-focus-inner,
+input::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+/*
+ * 1. Remove default vertical scrollbar in IE 8/9.
+ * 2. Improve readability and alignment in all browsers.
+ */
+textarea {
+  overflow: auto;
+  /* 1 */
+  vertical-align: top;
+  /* 2 */
+}
+
+/* ==========================================================================
+   Tables
+   ========================================================================== */
+/*
+ * Remove most spacing between table cells.
+ */
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+/*------------------------------------*\
+    $RESET
+\*------------------------------------*/
+/**
+ * A more considered reset; more of a restart...
+ * As per: csswizardry.com/2011/10/reset-restarted
+ */
+/**
+* LetÔÇÖs make the box model all nice, shall we...?
+*/
+*, *:before, *:after {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -ms-box-sizing: border-box;
+  -o-box-sizing: border-box;
+  box-sizing: border-box;
+}
+
+/**
+ * The usual...
+ */
+h1, h2, h3, h4, h5, h6,
+p, blockquote, pre,
+dl, dd, ol, ul,
+form, fieldset, legend,
+table, th, td, caption,
+hr {
+  margin: 0;
+  padding: 0;
+}
+
+/**
+ * Give a help cursor to elements that give extra info on `:hover`.
+ */
+abbr[title], dfn[title] {
+  cursor: help;
+}
+
+/**
+ * Remove underlines from potentially troublesome elements.
+ */
+u, ins {
+  text-decoration: none;
+}
+
+/**
+ * Apply faux underline via `border-bottom`.
+ */
+ins {
+  border-bottom: 1px solid;
+}
+
+/**
+ * So that `alt` text is visually offset if images donÔÇÖt load.
+ */
+img {
+  font-style: italic;
+}
+
+/**
+ * Give form elements some cursor interactions...
+ */
+label,
+input,
+textarea,
+button,
+select,
+option {
+  cursor: pointer;
+}
+
+.text-input:active,
+.text-input:focus,
+textarea:active,
+textarea:focus {
+  cursor: text;
+  outline: none;
+}
+
+/*------------------------------------*\
+    $CLEARFIX
+\*------------------------------------*/
+/**
+ * Micro clearfix, as per: css-101.org/articles/clearfix/latest-new-clearfix-so-far.php
+ * Extend the clearfix class with Sass to avoid the `.cf` class appearing over
+ * and over in your markup.
+ */
+.cf:after, .nav:after, .media:after, .island:after,
+.islet:after, .matrix:after, .multi-list:after, .stat-group:after {
+  content: "";
+  display: table;
+  clear: both;
+}
+
+/*------------------------------------*\
+    $SHARED
+\*------------------------------------*/
+/**
+ * Where `margin-bottom` is concerned, this value will be the same as the
+ * base line-height. This allows us to keep a consistent vertical rhythm.
+ * As per: csswizardry.com/2012/06/single-direction-margin-declarations
+ */
+/**
+ * Base elements
+ */
+h1, h2, h3, h4, h5, h6, hgroup,
+ul, ol, dl,
+blockquote, p, address,
+table,
+fieldset, figure,
+pre,
+.form-fields > li,
+.media,
+.island,
+.islet {
+  margin-bottom: 24px;
+  margin-bottom: 1.5rem;
+}
+.islet h1, .islet h2, .islet h3, .islet h4, .islet h5, .islet h6, .islet hgroup, .islet
+ul, .islet ol, .islet dl, .islet
+blockquote, .islet p, .islet address, .islet
+table, .islet
+fieldset, .islet figure, .islet
+pre, .islet .form-fields > li, .islet
+.media, .islet
+.island, .islet
+.islet {
+  margin-bottom: 12px;
+  margin-bottom: 0.75rem;
+}
+
+/**
+ * Doubled up `margin-bottom` helper class.
+ */
+.landmark {
+  margin-bottom: 48px;
+  margin-bottom: 3rem;
+}
+
+/**
+ * `hr` elements only take up a few pixels, so we need to give them special
+ * treatment regarding vertical rhythm.
+ */
+hr {
+  margin-bottom: 22px;
+  margin-bottom: 1.375rem;
+}
+
+/**
+ * Where `margin-left` is concerned we want to try and indent certain elements
+ * by a consistent amount. Define that amount once, here.
+ */
+ul, ol, dd {
+  margin-left: 48px;
+  margin-left: 3rem;
+}
+
+/**
+ * Base styles; unclassed HTML elements etc.
+ */
+/*------------------------------------*\
+    $MAIN
+\*------------------------------------*/
+html {
+  font: 1em/1.5 sans-serif;
+  overflow-y: scroll;
+  min-height: 100%;
+}
+
+/*------------------------------------*\
+    $HEADINGS
+\*------------------------------------*/
+/**
+ * As per: csswizardry.com/2012/02/pragmatic-practical-font-sizing-in-css
+ *
+ * When we define a heading we also define a corresponding class to go with it.
+ * This allows us to apply, say, `class=alpha` to a `h3`; a double-stranded
+ * heading hierarchy.
+ */
+h1, .alpha {
+  font-size: 36px;
+  font-size: 2.25rem;
+  line-height: 1.33333;
+}
+
+h2, .beta {
+  font-size: 30px;
+  font-size: 1.875rem;
+  line-height: 1.6;
+}
+
+h3, .gamma {
+  font-size: 24px;
+  font-size: 1.5rem;
+  line-height: 1;
+}
+
+h4, .delta {
+  font-size: 20px;
+  font-size: 1.25rem;
+  line-height: 1.2;
+}
+
+h5, .epsilon {
+  font-size: 16px;
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+h6, .zeta {
+  font-size: 14px;
+  font-size: 0.875rem;
+  line-height: 1.71429;
+}
+
+/**
+ * Heading groups and generic any-heading class.
+ * To target any heading of any level simply apply a class of `.hN`, e.g.:
+ *
+   <hgroup>
+       <h1 class=hN>inuit.css</h1>
+       <h2 class=hN>Best. Framework. Ever!</h2>
+   </hgroup>
+ *
+ */
+hgroup .hN {
+  margin-bottom: 0;
+}
+
+/**
+ * A series of classes for setting massive type; for use in heroes, mastheads,
+ * promos, etc.
+ */
+.giga {
+  font-size: 96px;
+  font-size: 6rem;
+  line-height: 1;
+}
+
+.mega {
+  font-size: 72px;
+  font-size: 4.5rem;
+  line-height: 1;
+}
+
+.kilo {
+  font-size: 48px;
+  font-size: 3rem;
+  line-height: 1;
+}
+
+/*------------------------------------*\
+    $PARAGRAPHS
+\*------------------------------------*/
+/**
+ * The `.lede` class is used to make the introductory text (usually a paragraph)
+ * of a document slightly larger.
+ */
+.lede,
+.lead {
+  font-size: 18px;
+  font-size: 1.125rem;
+  line-height: 1.33333;
+}
+
+/*------------------------------------*\
+    $SMALLPRINT
+\*------------------------------------*/
+/**
+ * A series of classes for setting tiny type; for use in smallprint etc.
+ */
+.smallprint,
+.milli {
+  font-size: 12px;
+  font-size: 0.75rem;
+  line-height: 2;
+}
+
+.micro {
+  font-size: 10px;
+  font-size: 0.625rem;
+  line-height: 2.4;
+}
+
+/*------------------------------------*\
+    $QUOTES
+\*------------------------------------*/
+/**
+ * If English quotes are set in `_vars.scss`, define them here.
+ */
+/**
+ * Big up @boblet: html5doctor.com/blockquote-q-cite
+ */
+/**
+ * Inline quotes.
+ */
+q {
+  quotes: "\2018" "\2019" "\201C" "\201D";
+}
+q:before {
+  content: "\2018";
+  content: open-quote;
+}
+q:after {
+  content: "\2019";
+  content: close-quote;
+}
+q q:before {
+  content: "\201C";
+  content: open-quote;
+}
+q q:after {
+  content: "\201D";
+  content: close-quote;
+}
+
+blockquote {
+  quotes: "\201C" "\201D";
+}
+blockquote p:before {
+  content: "\201C";
+  content: open-quote;
+}
+blockquote p:after {
+  content: "";
+  content: no-close-quote;
+}
+blockquote p:last-of-type:after {
+  content: "\201D";
+  content: close-quote;
+}
+blockquote q:before {
+  content: "\2018";
+  content: open-quote;
+}
+blockquote q:after {
+  content: "\2019";
+  content: close-quote;
+}
+
+/**
+ *
+   <blockquote>
+       <p>Insanity: doing the same thing over and over again and expecting
+       different results.</p>
+       <b class=source>Albert Einstein</b>
+   </blockquote>
+ *
+ */
+blockquote {
+  /**
+   * .4em is roughly equal to the width of the opening ÔÇ£ that we wish to hang.
+   */
+  text-indent: -0.41em;
+}
+blockquote p:last-of-type {
+  margin-bottom: 0;
+}
+
+.source {
+  display: block;
+  text-indent: 0;
+}
+.source:before {
+  content: "\2014";
+}
+
+/*------------------------------------*\
+    $CODE
+\*------------------------------------*/
+/**
+ * Use an explicit font stack to ensure browsers render correct `line-height`.
+ */
+pre {
+  overflow: auto;
+}
+
+pre mark {
+  background: none;
+  border-bottom: 1px solid;
+  color: inherit;
+}
+
+/**
+ * Add comments to your code examples, e.g.:
+ *
+   <code>&lt;/div&gt;<span class=code-comment>&lt;!-- /wrapper --&gt;</span></code>
+ *
+ */
+.code-comment {
+  /**
+   * Override this setting in your theme stylesheet
+   */
+  opacity: 0.75;
+  filter: alpha(opacity=75);
+}
+
+/**
+ * You can add line numbers to your code examples but be warned, it requires
+ * some pretty funky looking markup, e.g.:
+ *
+   <ol class=line-numbers>
+       <li><code>.nav{</code></li>
+       <li><code>    list-style:none;</code></li>
+       <li><code>    margin-left:0;</code></li>
+       <li><code>}</code></li>
+       <li><code>    .nav > li,</code></li>
+       <li><code>        .nav > li > a{</code></li>
+       <li><code>            display:inline-block;</code></li>
+       <li><code>           *display:inline-block;</code></li>
+       <li><code>            zoom:1;</code></li>
+       <li><code>        }</code></li>
+   </ol>
+ *
+ * 1. Make the list look like code.
+ * 2. Give the list flush numbers with a leading zero.
+ * 3. Make sure lines of code donÔÇÖt wrap.
+ * 4. Give the code form by forcing the `code` to honour white-space.
+ */
+.line-numbers {
+  font-family: monospace, serif;
+  /* [1] */
+  list-style: decimal-leading-zero inside;
+  /* [2] */
+  white-space: nowrap;
+  /* [3] */
+  overflow: auto;
+  /* [3] */
+  margin-left: 0;
+}
+
+.line-numbers code {
+  white-space: pre;
+  /* [4] */
+}
+
+/*------------------------------------*\
+    $IMAGES
+\*------------------------------------*/
+/**
+ * Demo: jsfiddle.net/inuitcss/yMtur
+ */
+/**
+ * Fluid images.
+ */
+img {
+  max-width: 100%;
+}
+
+/**
+ * Non-fluid images if you specify `width` and/or `height` attributes.
+ */
+img[width],
+img[height] {
+  max-width: none;
+}
+
+/**
+ * Rounded images.
+ */
+.img--round {
+  border-radius: 4px;
+}
+
+/**
+ * Image placement variations.
+ */
+.img--right {
+  float: right;
+  margin-bottom: 24px;
+  margin-left: 24px;
+}
+
+.img--left {
+  float: left;
+  margin-right: 24px;
+  margin-bottom: 24px;
+}
+
+.img--center {
+  display: block;
+  margin-right: auto;
+  margin-bottom: 24px;
+  margin-left: auto;
+}
+
+/**
+ * Keep your images on your baseline.
+ *
+ * Please note, these will not work too nicely with fluid images and will
+ * distort when resized below a certain width. Use with caution.
+ */
+.img--short {
+  height: 120px;
+}
+
+.img--medium {
+  height: 240px;
+}
+
+.img--tall {
+  height: 360px;
+}
+
+/**
+ * Images in `figure` elements.
+ */
+figure > img {
+  display: block;
+}
+
+/*------------------------------------*\
+    $LISTS
+\*------------------------------------*/
+/**
+ * Remove vertical spacing from nested lists.
+ */
+li > ul,
+li > ol {
+  margin-bottom: 0;
+}
+
+/**
+ * Have a numbered `ul` without the semantics implied by using an `ol`.
+ */
+/*ul*/
+.numbered-list {
+  list-style-type: decimal;
+}
+
+/*------------------------------------*\
+    $TABLES
+\*------------------------------------*/
+/**
+ * We have a lot at our disposal for making very complex table constructs, e.g.:
+ *
+   <table class="table--bordered  table--striped  table--data">
+       <colgroup>
+           <col class=t10>
+           <col class=t10>
+           <col class=t10>
+           <col>
+       </colgroup>
+       <thead>
+           <tr>
+               <th colspan=3>Foo</th>
+               <th>Bar</th>
+           </tr>
+           <tr>
+               <th>Lorem</th>
+               <th>Ipsum</th>
+               <th class=numerical>Dolor</th>
+               <th>Sit</th>
+           </tr>
+       </thead>
+       <tbody>
+           <tr>
+               <th rowspan=3>Sit</th>
+               <td>Dolor</td>
+               <td class=numerical>03.788</td>
+               <td>Lorem</td>
+           </tr>
+           <tr>
+               <td>Dolor</td>
+               <td class=numerical>32.210</td>
+               <td>Lorem</td>
+           </tr>
+           <tr>
+               <td>Dolor</td>
+               <td class=numerical>47.797</td>
+               <td>Lorem</td>
+           </tr>
+           <tr>
+               <th rowspan=2>Sit</th>
+               <td>Dolor</td>
+               <td class=numerical>09.640</td>
+               <td>Lorem</td>
+           </tr>
+           <tr>
+               <td>Dolor</td>
+               <td class=numerical>12.117</td>
+               <td>Lorem</td>
+           </tr>
+       </tbody>
+   </table>
+ *
+ */
+table {
+  width: 100%;
+}
+
+th,
+td {
+  padding: 6px;
+  text-align: left;
+}
+@media screen and (min-width: 480px) {
+  th,
+  td {
+    padding: 12px;
+  }
+}
+
+/**
+ * Cell alignments
+ */
+[colspan] {
+  text-align: center;
+}
+
+[colspan="1"] {
+  text-align: left;
+}
+
+[rowspan] {
+  vertical-align: middle;
+}
+
+[rowspan="1"] {
+  vertical-align: top;
+}
+
+.numerical {
+  text-align: right;
+}
+
+/**
+ * In the HTML above we see several `col` elements with classes whose numbers
+ * represent a percentage width for that column. We leave one column free of a
+ * class so that column can soak up the effects of any accidental breakage in
+ * the table.
+ */
+.t5 {
+  width: 5%;
+}
+
+.t10 {
+  width: 10%;
+}
+
+.t12 {
+  width: 12.5%;
+}
+
+/* 1/8 */
+.t15 {
+  width: 15%;
+}
+
+.t20 {
+  width: 20%;
+}
+
+.t25 {
+  width: 25%;
+}
+
+/* 1/4 */
+.t30 {
+  width: 30%;
+}
+
+.t33 {
+  width: 33.333%;
+}
+
+/* 1/3 */
+.t35 {
+  width: 35%;
+}
+
+.t37 {
+  width: 37.5%;
+}
+
+/* 3/8 */
+.t40 {
+  width: 40%;
+}
+
+.t45 {
+  width: 45%;
+}
+
+.t50 {
+  width: 50%;
+}
+
+/* 1/2 */
+.t55 {
+  width: 55%;
+}
+
+.t60 {
+  width: 60%;
+}
+
+.t62 {
+  width: 62.5%;
+}
+
+/* 5/8 */
+.t65 {
+  width: 65%;
+}
+
+.t66 {
+  width: 66.666%;
+}
+
+/* 2/3 */
+.t70 {
+  width: 70%;
+}
+
+.t75 {
+  width: 75%;
+}
+
+/* 3/4*/
+.t80 {
+  width: 80%;
+}
+
+.t85 {
+  width: 85%;
+}
+
+.t87 {
+  width: 87.5%;
+}
+
+/* 7/8 */
+.t90 {
+  width: 90%;
+}
+
+.t95 {
+  width: 95%;
+}
+
+/**
+ * Bordered tables
+ */
+.table--bordered th,
+.table--bordered td {
+  border: 1px solid #cccccc;
+}
+.table--bordered th:empty,
+.table--bordered td:empty {
+  border: none;
+}
+.table--bordered thead tr:last-child th {
+  border-bottom-width: 2px;
+}
+.table--bordered tbody tr th:last-of-type {
+  border-right-width: 2px;
+}
+
+/**
+ * Striped tables
+ */
+.table--striped tbody tr:nth-of-type(odd) {
+  background-color: #ffc;
+  /* Override this color in your theme stylesheet */
+}
+
+/**
+ * Data table
+ */
+.table--data {
+  font: 12px/1.5 sans-serif;
+}
+
+/*------------------------------------*\
+    $FORMS
+\*------------------------------------*/
+/**
+ *
+ * Demo: jsfiddle.net/inuitcss/MhHHU
+ *
+ */
+fieldset {
+  padding: 24px;
+}
+
+/**
+ * Text inputs
+ *
+ * Instead of a `[type]` selector for each kind of form input, we just use a
+ * class to target any/every one, e.g.:
+   <input type=text class=text-input>
+   <input type=email class=text-input>
+   <input type=password class=text-input>
+ *
+ */
+.text-input,
+textarea {
+  /**
+   * Style these via your theme stylesheet.
+   */
+}
+
+/**
+ * Group sets of form fields in a list, e.g.:
+ *
+   <ul class=form-fields>
+       <li>
+           <label />
+           <input />
+       </li>
+       <li>
+           <label />
+           <select />
+       </li>
+       <li>
+           <label />
+           <input />
+       </li>
+   </ul>
+ *
+ */
+.form-fields {
+  list-style: none;
+  margin: 0;
+}
+
+.form-fields > li:last-child {
+  margin-bottom: 0;
+}
+
+/**
+ * Labels
+ *
+ * Define a `.label` class as well as a `label` element. This means we can apply
+ * label-like styling to meta-labels for groups of options where a `label`
+ * element is not suitable, e.g.:
+ *
+   <li>
+       <span class=label>Select an option below:</span>
+       <ul class="multi-list  four-cols">
+           <li>
+               <input /> <label />
+           </li>
+           <li>
+               <input /> <label />
+           </li>
+           <li>
+               <input /> <label />
+           </li>
+           <li>
+               <input /> <label />
+           </li>
+       </ul>
+   </li>
+ *
+ */
+label,
+.label {
+  display: block;
+}
+
+/**
+ * Extra help text in `label`s, e.g.:
+ *
+   <label>Card number <small class=additional>No spaces</small></label>
+ *
+ */
+.additional {
+  display: block;
+  font-weight: normal;
+}
+
+/*
+ * Groups of checkboxes and radios, e.g.:
+ *
+   <li>
+       <ul class=check-list>
+           <li>
+               <input /> <label />
+           </li>
+           <li>
+               <input /> <label />
+           </li>
+       </ul>
+   </li>
+ *
+ */
+.check-list {
+  list-style: none;
+  margin: 0;
+}
+
+/*
+ * Labels in check-lists
+ */
+.check-label,
+.check-list label,
+.check-list .label {
+  display: inline-block;
+}
+
+/**
+ * Spoken forms are for forms that read like spoken word, e.g.:
+ *
+   <li class=spoken-form>
+       Hello, my <label for=spoken-name>name</label> is
+       <input type=text class=text-input id=spoken-name>. My home
+       <label for=country>country</label> is
+       <select id=country>
+           <option>UK</option>
+           <option>US</option>
+           <option>Other</option>
+       </select>
+   </li>
+ *
+ */
+.spoken-form label {
+  display: inline-block;
+  font: inherit;
+}
+
+/**
+ * Extra help text displayed after a field when that field is in focus, e.g.:
+ *
+   <label for=email>Email:</label>
+   <input type=email class=text-input id=email>
+   <small class=extra-help>.edu emails only</small>
+ *
+ * We leave the help text in the document flow and merely set it to
+ * `visibility:hidden;`. This means that it wonÔÇÖt interfere with anything once
+ * it reappears.
+ *
+ */
+/*small*/
+.extra-help {
+  display: inline-block;
+  visibility: hidden;
+}
+
+.text-input:active + .extra-help,
+.text-input:focus + .extra-help {
+  visibility: visible;
+}
+
+/**
+ * Objects and abstractions
+ */
+/*------------------------------------*\
+    $GRIDS
+\*------------------------------------*/
+/**
+ * Fluid and nestable grid system, e.g.:
+ *
+   <div class="grid">
+
+       <div class="grid__item  one-third">
+           <p>One third grid</p>
+       </div><!--
+
+    --><div class="grid__item  two-thirds">
+           <p>Two thirds grid</p>
+       </div><!--
+
+    --><div class="grid__item  one-half">
+           <p>One half grid</p>
+       </div><!--
+
+    --><div class="grid__item  one-quarter">
+           <p>One quarter grid</p>
+       </div><!--
+
+    --><div class="grid__item  one-quarter">
+           <p>One quarter grid</p>
+       </div>
+
+   </div>
+ *
+ * The grid system is based on csswizardry-grids: github.com/csswizardry/csswizardry-grids
+ * If you would like to use the full features of csswizardry-grids then you can
+ * simply use it in conjunction with inuit.css as a second library.
+ *
+ * Demo: jsfiddle.net/inuitcss/CLYUC
+ *
+ */
+/**
+ * Grid wrapper
+ */
+.grid, .grid--rev, .grid--full, .grid--center {
+  margin-left: -24px;
+  list-style: none;
+  margin-bottom: 0;
+}
+
+/**
+ * Very infrequently occuring grid wrappers as children of grid wrappers.
+ */
+.grid > .grid, .grid--rev > .grid, .grid--full > .grid, .grid--center > .grid, .grid > .grid--rev, .grid--rev > .grid--rev, .grid--full > .grid--rev, .grid--center > .grid--rev, .grid > .grid--full, .grid--rev > .grid--full, .grid--full > .grid--full, .grid--center > .grid--full, .grid > .grid--center, .grid--rev > .grid--center, .grid--full > .grid--center, .grid--center > .grid--center {
+  margin-left: 0;
+}
+
+/**
+ * Grid
+ */
+.grid__item {
+  display: inline-block;
+  width: 100%;
+  padding-left: 24px;
+  vertical-align: top;
+}
+
+/**
+ * Reversed grids
+ */
+.grid--rev {
+  direction: rtl;
+  text-align: right;
+}
+.grid--rev > .grid__item {
+  direction: ltr;
+  text-align: left;
+}
+
+/**
+ * Gutterless grids have all the properties of regular grids, minus any spacing.
+ */
+.grid--full {
+  margin-left: 0;
+}
+.grid--full > .grid__item {
+  padding-left: 0;
+}
+
+/**
+ * Centered grids align grid items centrally without needing to use push or pull
+ * classes.
+ */
+.grid--center {
+  text-align: center;
+}
+.grid--center > .grid__item {
+  text-align: left;
+}
+
+/*------------------------------------*\
+    $FLEXBOX
+\*------------------------------------*/
+/**
+ * Until we can utilise flexbox natively we can kinda, sorta, attempt to emulate
+ * it, in a way... e.g.:
+ *
+   <header class=flexbox>
+
+       <div class=flexbox__item>
+           <b>Welcome to</b>
+       </div>
+
+       <div class=flexbox__item>
+           <img src="//csswizardry.com/inuitcss/img/logo.jpg" alt="inuit.css">
+       </div>
+
+   </header>
+ *
+ * We can also combine our grid system classes with `.flexbox__item` classes,
+ * e.g.:
+ *
+   <div class=flexbox>
+       <div class="flexbox__item  one-quarter">
+       </div>
+       <div class="flexbox__item  three-quarters">
+       </div>
+   </div>
+ *
+ * ItÔÇÖs pretty poorly named IÔÇÖm afraid, but it works...
+ *
+ * Demo: jsfiddle.net/inuitcss/ufUh2
+ *
+ */
+.flexbox {
+  display: table;
+  width: 100%;
+}
+
+/**
+ * Nasty hack to circumvent Modernizr conflicts.
+ */
+html.flexbox {
+  display: block;
+  width: auto;
+}
+
+.flexbox__item {
+  display: table-cell;
+  vertical-align: middle;
+}
+
+/*------------------------------------*\
+    $COLUMNS
+\*------------------------------------*/
+/**
+ * Here we can set elements in columns of text using CSS3, e.g.:
+ *
+   <p class=text-cols--2>
+ *
+ * Demo: jsfiddle.net/inuitcss/E26Yd
+ *
+ */
+.text-cols--2, .text-cols--3, .text-cols--4, .text-cols--5 {
+  -webkit-column-gap: 24px;
+  -moz-column-gap: 24px;
+  -ms-column-gap: 24px;
+  -o-column-gap: 24px;
+  column-gap: 24px;
+}
+
+.text-cols--2 {
+  -webkit-column-count: 2;
+  -moz-column-count: 2;
+  -ms-column-count: 2;
+  -o-column-count: 2;
+  column-count: 2;
+}
+
+.text-cols--3 {
+  -webkit-column-count: 3;
+  -moz-column-count: 3;
+  -ms-column-count: 3;
+  -o-column-count: 3;
+  column-count: 3;
+}
+
+.text-cols--4 {
+  -webkit-column-count: 4;
+  -moz-column-count: 4;
+  -ms-column-count: 4;
+  -o-column-count: 4;
+  column-count: 4;
+}
+
+.text-cols--5 {
+  -webkit-column-count: 5;
+  -moz-column-count: 5;
+  -ms-column-count: 5;
+  -o-column-count: 5;
+  column-count: 5;
+}
+
+/*------------------------------------*\
+    $NAV
+\*------------------------------------*/
+/**
+ * Nav abstraction as per: csswizardry.com/2011/09/the-nav-abstraction
+ * When used on an `ol` or `ul`, this class throws the list into horizontal mode
+ * e.g.:
+ *
+   <ul class=nav>
+       <li><a href=#>Home</a></li>
+       <li><a href=#>About</a></li>
+       <li><a href=#>Portfolio</a></li>
+       <li><a href=#>Contact</a></li>
+   </ul>
+ *
+ * Demo: jsfiddle.net/inuitcss/Vnph4
+ *
+ */
+.nav {
+  list-style: none;
+  margin-left: 0;
+}
+.nav > li,
+.nav > li > a {
+  display: inline-block;
+  *display: inline;
+  zoom: 1;
+}
+
+/**
+ * `.nav--stacked` extends `.nav` and throws the list into vertical mode, e.g.:
+ *
+   <ul class="nav  nav--stacked">
+       <li><a href=#>Home</a></li>
+       <li><a href=#>About</a></li>
+       <li><a href=#>Portfolio</a></li>
+       <li><a href=#>Contact</a></li>
+   </ul>
+ *
+ */
+.nav--stacked > li {
+  display: list-item;
+}
+.nav--stacked > li > a {
+  display: block;
+}
+
+/**
+ * `.nav--banner` extends `.nav` and centres the list, e.g.:
+ *
+   <ul class="nav  nav--banner">
+       <li><a href=#>Home</a></li>
+       <li><a href=#>About</a></li>
+       <li><a href=#>Portfolio</a></li>
+       <li><a href=#>Contact</a></li>
+   </ul>
+ *
+ */
+.nav--banner {
+  text-align: center;
+}
+
+/**
+ * Give nav links a big, blocky hit area. Extends `.nav`, e.g.:
+ *
+   <ul class="nav  nav--block">
+       <li><a href=#>Home</a></li>
+       <li><a href=#>About</a></li>
+       <li><a href=#>Portfolio</a></li>
+       <li><a href=#>Contact</a></li>
+   </ul>
+ *
+ */
+.nav--block, .options {
+  line-height: 1;
+  /**
+   * Remove whitespace caused by `inline-block`.
+   */
+  letter-spacing: -0.31em;
+  word-spacing: -0.43em;
+  white-space: nowrap;
+}
+.nav--block > li, .options > li {
+  letter-spacing: normal;
+  word-spacing: normal;
+}
+.nav--block > li > a, .options > li > a {
+  padding: 12px;
+}
+
+/**
+ * Force a nav to occupy 100% of the available width of its parent. Extends
+ * `.nav`, e.g.:
+ *
+   <ul class="nav  nav--fit">
+       <li><a href=#>Home</a></li>
+       <li><a href=#>About</a></li>
+       <li><a href=#>Portfolio</a></li>
+       <li><a href=#>Contact</a></li>
+   </ul>
+ *
+ * Thanks to @pimpl for this idea!
+ */
+.nav--fit {
+  display: table;
+  width: 100%;
+}
+.nav--fit > li {
+  display: table-cell;
+}
+.nav--fit > li > a {
+  display: block;
+}
+
+/**
+ * Make a list of keywords. Extends `.nav`, e.g.:
+ *
+   `<ul class="nav  nav--keywords>`
+ *
+ */
+.nav--keywords > li:after {
+  content: "\002C" "\00A0";
+}
+.nav--keywords > li:last-child:after {
+  display: none;
+}
+
+/*------------------------------------*\
+    $OPTIONS
+\*------------------------------------*/
+/**
+ * Link-group nav, used for displaying related options. Extends `.nav--block`
+ * but could also extend `.nav--fit`. Extend with colours and ÔÇÿcurrent statesÔÇÖ
+ * in your theme stylesheet.
+ *
+  <ul class="nav  options">
+      <li><a></a></li>
+      <li><a></a></li>
+      <li><a></a></li>
+      <li><a></a></li>
+   </ul>
+ *
+ * Demo: jsfiddle.net/inuitcss/vwfaf
+ *
+ */
+.options > li > a {
+  border: 0 solid #cccccc;
+  border-width: 1px;
+  border-left-width: 0;
+}
+.options > li:first-child > a {
+  border-left-width: 1px;
+  border-top-left-radius: 4px;
+  border-bottom-left-radius: 4px;
+}
+.options > li:last-child > a {
+  border-top-right-radius: 4px;
+  border-bottom-right-radius: 4px;
+}
+
+/*------------------------------------*\
+    $PAGINATION
+\*------------------------------------*/
+/**
+ * Basic pagination object, extends `.nav`.
+ * Requires some funky commenting to collapse any white-space caused by the
+ * `display:inline-block;` rules.
+ *
+   <ol class="nav  pagination">
+       <li class=pagination__first>First</li>
+       <li class=pagination__prev>Previous</li>
+       <li><a href=/page/1>1</a></li>
+       <li><a href=/page/2>2</a></li>
+       <li class=current><a href=/page/3>3</a></li>
+       <li><a href=/page/4>4</a></li>
+       <li><a href=/page/5>5</a></li>
+       <li class=pagination__next><a href=/page/next>Next</a></li>
+       <li class=pagination__last><a href=/page/last>Last</a></li>
+   </ol>
+ *
+ * Demo: jsfiddle.net/inuitcss/9Y6PU
+ *
+ */
+.pagination {
+  text-align: center;
+  /**
+   * Remove whitespace caused by `inline-block`.
+   */
+  letter-spacing: -0.31em;
+  word-spacing: -0.43em;
+}
+
+.pagination > li {
+  padding: 12px;
+  letter-spacing: normal;
+  word-spacing: normal;
+}
+
+.pagination > li > a {
+  padding: 12px;
+  margin: -12px;
+}
+
+.pagination__first a:before {
+  content: "\00AB" "\00A0";
+}
+
+.pagination__last a:after {
+  content: "\00A0" "\00BB";
+}
+
+/*------------------------------------*\
+    $BREADCRUMB
+\*------------------------------------*/
+/**
+ * Simple breadcrumb styling to apply to (ordered) lists. Extends `.nav`, e.g.:
+ *
+   <ol class="nav  breadcrumb">
+       <li><a href=#>Home</a></li>
+       <li><a href=#>About</a></li>
+       <li><a href=#>The Board</a></li>
+       <li class=current><a href=#>Directors</a></li>
+   </ol>
+ *
+ * Demo: jsfiddle.net/inuitcss/rkAY9
+ *
+ */
+.breadcrumb > li + li:before {
+  content: "\00BB" "\00A0";
+}
+
+/**
+ * For denoting a path-like structure, GitHub style, e.g.:
+ *
+   <ol class="nav  breadcrumb--path">
+       <li class=breadcrumb__root><a href=#>inuit.css</a></li>
+       <li><a href=#>inuit.css</a></li>
+       <li><a href=#>partials</a></li>
+       <li class=current><a href=#>objects</a></li>
+   </ol>
+ *
+ */
+.breadcrumb--path > li + li:before {
+  content: "\002F" "\00A0";
+}
+
+/**
+ * Assign a delimiter on the fly through a data attribute, e.g.:
+ *
+   <ol class="nav  breadcrumb">
+       <li><a href=#>Home</a></li>
+       <li data-breadcrumb="|"><a href=#>About</a></li>
+       <li data-breadcrumb="|"><a href=#>The Board</a></li>
+       <li data-breadcrumb="|" class=current><a href=#>Directors</a></li>
+   </ol>
+ *
+ */
+.breadcrumb > li + li[data-breadcrumb]:before {
+  content: attr(data-breadcrumb) "\00A0";
+}
+
+/**
+ * Denote the root of the tree.
+ */
+.breadcrumb__root {
+  font-weight: bold;
+}
+
+/*------------------------------------*\
+    $MEDIA
+\*------------------------------------*/
+/**
+ * Place any image- and text-like content side-by-side, as per:
+ * stubbornella.org/content/2010/06/25/the-media-object-saves-hundreds-of-lines-of-code
+ * E.g.:
+ *
+   <div class=media>
+       <img src=http://placekitten.com/200/300 alt="" class=media__img>
+       <p class=media__body>Lorem ipsum dolor sit amet, consectetur adipisicing elit,
+       sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+   </div>
+ *
+ * Demo: jsfiddle.net/inuitcss/cf4Qs
+ *
+ */
+.media {
+  display: block;
+}
+
+.media__img {
+  float: left;
+  margin-right: 24px;
+}
+
+/**
+ * Reversed image location (right instead of left).
+ */
+.media__img--rev {
+  float: right;
+  margin-left: 24px;
+}
+
+.media__img img,
+.media__img--rev img {
+  display: block;
+}
+
+.media__body {
+  overflow: hidden;
+}
+
+.media__body,
+.media__body > :last-child {
+  margin-bottom: 0;
+}
+
+/**
+ * `.img`s in `.islet`s need an appropriately sized margin.
+ */
+.islet .media__img {
+  margin-right: 12px;
+}
+
+.islet .media__img--rev {
+  margin-left: 12px;
+}
+
+/*------------------------------------*\
+    $MARGINALIA
+\*------------------------------------*/
+/**
+ * Marginalia are, per definition, notes in the margin of a document. The
+ * `marginalia__body` class can be applied to all kinds of content, like text or
+ * images, and is joined by a width class:
+ *
+   <div class="marginalia">
+       <div class="marginalia__body  desk-one-fifth"></div>
+   </div>
+ *
+ * Demo: jsfiddle.net/inuitcss/AemkH
+ *
+ */
+.marginalia {
+  font-size: 12px;
+  font-size: 0.75rem;
+  line-height: 2;
+}
+
+/**
+ * Wait for a certain breakpoint to trigger ÔÇÿproper' marginalia. Up to this point,
+ * marginalia are inline with the other text.
+ */
+@media (min-width: 1024px) {
+  .marginalia {
+    position: relative;
+  }
+
+  .marginalia__body,
+  .marginalia__body--right {
+    position: absolute;
+  }
+
+  .marginalia__body {
+    right: 100%;
+    padding-right: 24px;
+    text-align: right;
+  }
+
+  /**
+   * Align marginalia to the right of the text.
+   */
+  .marginalia__body--right {
+    left: 100%;
+    padding-left: 24px;
+    text-align: left;
+  }
+}
+/*------------------------------------*\
+    $ISLAND
+\*------------------------------------*/
+/**
+ * Simple, boxed off content, as per: csswizardry.com/2011/10/the-island-object
+ * E.g.:
+ *
+   <div class=island>
+       I am boxed off.
+   </div>
+ *
+ * Demo: jsfiddle.net/inuitcss/u8pV3
+ *
+ */
+.island,
+.islet {
+  display: block;
+}
+
+.island {
+  padding: 24px;
+}
+
+.island > :last-child,
+.islet > :last-child {
+  margin-bottom: 0;
+}
+
+/**
+ * Just like `.island`, only smaller.
+ */
+.islet {
+  padding: 12px;
+}
+
+/*------------------------------------*\
+    $BLOCK-LIST
+\*------------------------------------*/
+/**
+ * Create big blocky lists of content, e.g.:
+ *
+   <ul class=block-list>
+      <li>Foo</li>
+      <li>Bar</li>
+      <li>Baz</li>
+      <li><a href=# class=block-list__link>Foo Bar Baz</a></li>
+   </ul>
+ *
+ * Extend this object in your theme stylesheet.
+ *
+ * Demo: jsfiddle.net/inuitcss/hR57q
+ *
+ */
+.block-list, .matrix,
+.block-list > li,
+.matrix > li {
+  border: 0 solid #cccccc;
+}
+
+.block-list, .matrix {
+  list-style: none;
+  margin-left: 0;
+  border-top-width: 1px;
+}
+.block-list > li, .matrix > li {
+  border-bottom-width: 1px;
+  padding: 12px;
+}
+
+.block-list__link, .matrix__link {
+  display: block;
+  padding: 12px;
+  margin: -12px;
+}
+
+/*------------------------------------*\
+    $MATRIX
+\*------------------------------------*/
+/**
+ * Create a grid of items out of a single list, e.g.:
+ *
+   <ul class="matrix  three-cols">
+       <li class=all-cols>Lorem</li>
+       <li>Ipsum <a href=#>dolor</a></li>
+       <li><a href=# class=matrix__link>Sit</a></li>
+       <li>Amet</li>
+       <li class=all-cols>Consectetuer</li>
+   </ul>
+ *
+ * Extend this object in your theme stylesheet.
+ *
+ * Demo: jsfiddle.net/inuitcss/Y2zrU
+ *
+ */
+.matrix {
+  border-left-width: 1px;
+}
+.matrix > li {
+  float: left;
+  border-right-width: 1px;
+}
+
+/**
+ * The `.multi-list` object is a lot like the `.matrix` object only without the
+ * blocky borders and padding.
+ *
+   <ul class="multi-list  four-cols">
+       <li>Lorem</li>
+       <li>Ipsum</li>
+       <li>Dolor</li>
+       <li>Sit</li>
+   </ul>
+ *
+ * Demo: jsfiddle.net/inuitcss/Y2zrU
+ *
+ */
+.multi-list {
+  list-style: none;
+  margin-left: 0;
+}
+
+.multi-list > li {
+  float: left;
+}
+
+/**
+ * Apply these classes alongside the `.matrix` or `.multi-list` classes on
+ * lists to determine how wide their columns are.
+ */
+.two-cols > li {
+  width: 50%;
+}
+
+.three-cols > li {
+  width: 33.333%;
+}
+
+.four-cols > li {
+  width: 25%;
+}
+
+.five-cols > li {
+  width: 20%;
+}
+
+/**
+ * Unfortunately we have to qualify this selector in order to bring its
+ * specificity above the `.[number]-cols > li` selectors above.
+ */
+.matrix > .all-cols,
+.multi-list > .all-cols {
+  width: 100%;
+}
+
+/*------------------------------------*\
+    $SPLIT
+\*------------------------------------*/
+/**
+ * Simple split item for creating two elements floated away from one another,
+ * e.g.:
+ *
+   <dl class=split>
+       <dt class=split__title>Burger and fries</dt>
+       <dd>&pound;5.99</dd>
+       <dt class=split__title>Fillet steak</dt>
+       <dd>&pound;19.99</dd>
+       <dt class=split__title>Ice cream</dt>
+       <dd>&pound;2.99</dd>
+   </dl>
+ *
+   <ol class="split  results">
+       <li class=first><b class=split__title>1st place</b> Bob</li>
+       <li class=second><b class=split__title>2nd place</b> Lilly</li>
+       <li class=third><b class=split__title>3rd place</b> Ted</li>
+   </ol>ÔÇï
+ *
+ * Demo: jsfiddle.net/inuitcss/9gZW7
+ *
+ */
+.split {
+  text-align: right;
+  list-style: none;
+  margin-left: 0;
+}
+
+.split__title {
+  text-align: left;
+  float: left;
+  clear: left;
+}
+
+/*------------------------------------*\
+    $THIS-OR-THIS
+\*------------------------------------*/
+/**
+ * Simple options object to provide multiple choices, e.g.:
+ *
+   <h1 class=this-or-this>
+       <a href=# class="this-or-this__this  two-fifths">
+           Free
+       </a>
+       <span class="this-or-this__or  one-fifth">
+           or
+       </span>
+       <a href=# class="this-or-this__this  two-fifths">
+           Pro
+       </a>
+   </h1>
+ *
+ * The `.this-or-this__this` and `.this-or-this__or` objects can be sized using
+ * the grid-system classes.
+ *
+ * Demo: jsfiddle.net/inuitcss/R3sks
+ *
+ */
+.this-or-this {
+  display: table;
+  width: 100%;
+  text-align: center;
+}
+
+.this-or-this__this,
+.this-or-this__or {
+  display: table-cell;
+  vertical-align: middle;
+}
+
+/*------------------------------------*\
+    $LINK-COMPLEX
+\*------------------------------------*/
+/**
+ * As inspired by @necolas:
+ * github.com/necolas/suit-utils/blob/master/link.css#L18
+ *
+ * Add hover behaviour to only selected items within links, e.g.:
+ *
+   <a href=log-in class=link-complex>
+       <i class="s  s--user"></i>
+       <span class=link-complex__target>Log in</span>
+   </a>
+ *
+ * Demo: jsfiddle.net/inuitcss/rt9M3
+ *
+ */
+.link-complex,
+.link-complex:hover,
+.link-complex:active,
+.link-complex:focus {
+  text-decoration: none;
+}
+
+.link-complex:hover .link-complex__target,
+.link-complex:active .link-complex__target,
+.link-complex:focus .link-complex__target {
+  text-decoration: underline;
+}
+
+/*------------------------------------*\
+    $FLYOUT
+\*------------------------------------*/
+/**
+ * Flyouts are pieces of content that fly out of a parent when said parent is
+ * hovered. They typically appear bottom-left of the parent.
+ *
+   <div class=flyout>
+       Foo
+       <div class=flyout__content>
+           <h1>Lorem</h1>
+           <p>Ipsum</p>
+       </div>
+   </div>
+ *
+ * Extend these objects in your theme stylesheet.
+ *
+ * Demo: jsfiddle.net/inuitcss/B52HG
+ *
+ */
+.flyout,
+.flyout--alt {
+  position: relative;
+  overflow: hidden;
+}
+
+.flyout__content {
+  /**
+   * Position the flyouts off-screen. This is typically better than
+   * `display:none;`.
+   */
+  position: absolute;
+  top: 100%;
+  left: -99999px;
+}
+
+/**
+ * Bring the flyouts into view when you hover their parents.
+ * Two different types of flyout; ÔÇÿregularÔÇÖ (`.flyout`) and ÔÇÿalternativeÔÇÖ
+ * (`.flyout--alt`).
+ */
+.flyout:hover,
+.flyout--alt:hover {
+  overflow: visible;
+}
+
+/**
+ * Regular flyouts sit all the way from the top, flush left.
+ */
+.flyout:hover > .flyout__content {
+  left: 0;
+}
+
+/**
+ * Alternative flyouts sit all the way from the left, flush top.
+ */
+.flyout--alt:hover > .flyout__content {
+  top: 0;
+  left: 100%;
+}
+
+/*------------------------------------*\
+    $ARROWS
+\*------------------------------------*/
+/**
+ * It is a common design treatment to give an element a triangular points-out
+ * arrow, we typically build these with CSS. These following classes allow us to
+ * generate these arbitrarily with a mixin, `@arrow()`.
+ */
+/**
+ * Forms the basis for any/all CSS arrows.
+ */
+.test-arrow--top-left, .test-arrow--top-right, .test-arrow--top-center, .test-arrow--right-top, .test-arrow--left-top, .test-arrow--right-center, .test-arrow--left-center, .test-arrow--right-bottom, .test-arrow--left-bottom, .test-arrow--bottom-left, .test-arrow--bottom-center, .test-arrow--bottom-right {
+  position: relative;
+}
+.test-arrow--top-left:before, .test-arrow--top-right:before, .test-arrow--top-center:before, .test-arrow--right-top:before, .test-arrow--left-top:before, .test-arrow--right-center:before, .test-arrow--left-center:before, .test-arrow--right-bottom:before, .test-arrow--left-bottom:before, .test-arrow--bottom-left:before, .test-arrow--bottom-center:before, .test-arrow--bottom-right:before, .test-arrow--top-left:after, .test-arrow--top-right:after, .test-arrow--top-center:after, .test-arrow--right-top:after, .test-arrow--left-top:after, .test-arrow--right-center:after, .test-arrow--left-center:after, .test-arrow--right-bottom:after, .test-arrow--left-bottom:after, .test-arrow--bottom-left:after, .test-arrow--bottom-center:after, .test-arrow--bottom-right:after {
+  content: "";
+  position: absolute;
+  border-collapse: separate;
+}
+.test-arrow--top-left:before, .test-arrow--top-right:before, .test-arrow--top-center:before, .test-arrow--right-top:before, .test-arrow--left-top:before, .test-arrow--right-center:before, .test-arrow--left-center:before, .test-arrow--right-bottom:before, .test-arrow--left-bottom:before, .test-arrow--bottom-left:before, .test-arrow--bottom-center:before, .test-arrow--bottom-right:before {
+  border: 12px solid transparent;
+}
+.test-arrow--top-left:after, .test-arrow--top-right:after, .test-arrow--top-center:after, .test-arrow--right-top:after, .test-arrow--left-top:after, .test-arrow--right-center:after, .test-arrow--left-center:after, .test-arrow--right-bottom:after, .test-arrow--left-bottom:after, .test-arrow--bottom-left:after, .test-arrow--bottom-center:after, .test-arrow--bottom-right:after {
+  border: 11px solid transparent;
+}
+
+/**
+ * Define individual edges so we can combine what we need, when we need.
+ */
+.test-arrow--top-left:before, .test-arrow--top-right:before, .test-arrow--top-center:before, .test-arrow--top-left:after, .test-arrow--top-right:after, .test-arrow--top-center:after {
+  bottom: 100%;
+}
+
+.test-arrow--right-top:before, .test-arrow--left-top:before {
+  top: 11px;
+}
+.test-arrow--right-top:after, .test-arrow--left-top:after {
+  top: 12px;
+}
+
+.test-arrow--right-center:before, .test-arrow--left-center:before, .test-arrow--right-center:after, .test-arrow--left-center:after {
+  top: 50%;
+  margin-top: -12px;
+}
+.test-arrow--right-center:after, .test-arrow--left-center:after {
+  margin-top: -11px;
+}
+
+.test-arrow--right-bottom:before, .test-arrow--left-bottom:before {
+  bottom: 11px;
+}
+.test-arrow--right-bottom:after, .test-arrow--left-bottom:after {
+  bottom: 12px;
+}
+
+.test-arrow--bottom-left:before, .test-arrow--bottom-center:before, .test-arrow--bottom-right:before, .test-arrow--bottom-left:after, .test-arrow--bottom-center:after, .test-arrow--bottom-right:after {
+  top: 100%;
+}
+
+.test-arrow--left-top:before, .test-arrow--left-center:before, .test-arrow--left-bottom:before, .test-arrow--left-top:after, .test-arrow--left-center:after, .test-arrow--left-bottom:after {
+  right: 100%;
+}
+
+.test-arrow--top-left:before, .test-arrow--bottom-left:before {
+  left: 11px;
+}
+.test-arrow--top-left:after, .test-arrow--bottom-left:after {
+  left: 12px;
+}
+
+.test-arrow--top-center:before, .test-arrow--bottom-center:before, .test-arrow--top-center:after, .test-arrow--bottom-center:after {
+  left: 50%;
+  margin-left: -12px;
+}
+.test-arrow--top-center:after, .test-arrow--bottom-center:after {
+  margin-left: -11px;
+}
+
+.test-arrow--top-right:before, .test-arrow--bottom-right:before {
+  right: 11px;
+}
+.test-arrow--top-right:after, .test-arrow--bottom-right:after {
+  right: 12px;
+}
+
+.test-arrow--right-top:before, .test-arrow--right-center:before, .test-arrow--right-bottom:before, .test-arrow--right-top:after, .test-arrow--right-center:after, .test-arrow--right-bottom:after {
+  left: 100%;
+}
+
+/*------------------------------------*\
+    $SPRITE
+\*------------------------------------*/
+/**
+ * Giving an element a class of `.sprite` will throw it into ÔÇÿspriteÔÇÖ mode and apply
+ * a background image e.g.:
+ *
+   <a class="sprite  sprite--question-mark">More info&hellip;</a>
+ *
+ * or
+ *
+   <a href=#><i class="sprite  sprite--question-mark"></i> Help and FAQ</a>
+ *
+ * Giving an element a class of `.icon` will throw it into ÔÇÿiconÔÇÖ mode and will
+ * not add a background, but should be used for icon fonts and is populated
+ * through a `data-icon` attribute and the `:after` pseudo-element, e.g.:
+ *
+   <a href=#><i class=icon data-icon="&#xF000;"></i> View your favourites</a>
+ *
+ * Where ÔÇÿ&#xF000;ÔÇÖ might map to a star in your particular icon font.
+ *
+ * These all require extension in your theme stylesheet, e.g. in your own CSS:
+ *
+   .sprite{
+       background-image:url(path/to/your/sprite.png);
+   }
+   .sprite--link{ background-position:0   0  ; }
+   .sprite--star{ background-position:0 -16px; }
+ *
+ * Demo: jsfiddle.net/inuitcss/6TKuS
+ *
+ */
+.sprite,
+.icon {
+  display: inline-block;
+  line-height: 1;
+  position: relative;
+  vertical-align: middle;
+  zoom: 1;
+  /**
+   * So using `.icon` on certain elements doesnÔÇÖt make a visual difference.
+   */
+  font-style: normal;
+  font-weight: normal;
+  /**
+   * So icons added using `.icon` sit in the centre of the element.
+   */
+  text-align: center;
+}
+
+.sprite {
+  /**
+   * The typical size of most icons. Override in your theme stylesheet.
+   */
+  width: 16px;
+  height: 16px;
+  top: -1px;
+  /*
+   * H5BP method image replacement:
+   * github.com/h5bp/html5-boilerplate/commit/adecc5da035d6d76b77e3fa95c6abde841073da2
+   */
+  overflow: hidden;
+  *text-indent: -9999px;
+}
+.sprite:before {
+  content: "";
+  display: block;
+  width: 0;
+  height: 100%;
+}
+
+/**
+ * Set up icon font
+ */
+.icon {
+  font-size: 16px;
+  /**
+   * Place the icon in a box the exact same dimensions as the icon itself.
+   */
+  width: 1em;
+  height: 1em;
+}
+.icon:before {
+  content: attr(data-icon);
+}
+
+/**
+ * Icon size modifiers.
+ */
+.icon--large {
+  font-size: 32px;
+}
+
+.icon--huge {
+  font-size: 64px;
+}
+
+.icon--natural {
+  font-size: inherit;
+}
+
+/*------------------------------------*\
+    $ICON-TEXT
+\*------------------------------------*/
+/**
+ * For text-links etc that have an icon with them. Sometimes whitespace would
+ * suffice in creating a gap between the icon and text, for example:
+ *
+   <a href=#>
+       <i class="s  s--help"></i> Help &amp; support
+   </a>
+ *
+ * However we will sometimes want a larger, explicity set gap:
+   <a href=# class=icon-text>
+       <i class="icon-text__icon  s  s--help"></i>Help &amp; support
+   </a>
+ *
+ * Demo: jsfiddle.net/inuitcss/Q6Lbf
+ *
+ */
+.icon-text > .icon-text__icon {
+  margin-right: 6px;
+}
+
+/**
+ * We can also reverse the direction of the margin for icons that appear to the
+ * right of the text content, thus:
+ *
+   <a href=# class=icon-text--rev>
+       Help &amp; support<i class="icon-text__icon  s  s--help"></i>
+   </a>
+ *
+ */
+.icon-text--rev > .icon-text__icon {
+  margin-left: 6px;
+}
+
+/*------------------------------------*\
+    $BEAUTONS.CSS
+\*------------------------------------*/
+/**
+ * beautons is a beautifully simple button toolkit.
+ *
+ * LICENSE
+ * 
+ * Copyright 2013 Harry Roberts
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+/**
+ * 
+ * @csswizardry -- csswizardry.com/beautons
+ * 
+ */
+/*------------------------------------*\
+    $BASE
+\*------------------------------------*/
+/**
+ * Base button styles.
+ *
+ * 1. Allow us to better style box model properties.
+ * 2. Line different sized buttons up a little nicer.
+ * 3. Stop buttons wrapping and looking broken.
+ * 4. Make buttons inherit font styles.
+ * 5. Force all elements using beautons to appear clickable.
+ * 6. Normalise box model styles.
+ * 7. If the buttonÔÇÖs text is 1em, and the button is (3 * font-size) tall, then
+ *    there is 1em of space above and below that text. We therefore apply 1em
+ *    of space to the left and right, as padding, to keep consistent spacing.
+ * 8. Basic cosmetics for default buttons. Change or override at will.
+ * 9. DonÔÇÖt allow buttons to have underlines; it kinda ruins the illusion.
+ */
+.btn {
+  display: inline-block;
+  /* [1] */
+  vertical-align: middle;
+  /* [2] */
+  white-space: nowrap;
+  /* [3] */
+  font-family: inherit;
+  /* [4] */
+  font-size: 100%;
+  /* [4] */
+  cursor: pointer;
+  /* [5] */
+  border: none;
+  /* [6] */
+  margin: 0;
+  /* [6] */
+  padding-top: 0;
+  /* [6] */
+  padding-bottom: 0;
+  /* [6] */
+  line-height: 3;
+  /* [7] */
+  padding-right: 1em;
+  /* [7] */
+  padding-left: 1em;
+  /* [7] */
+  background-color: #3f89c1;
+  /* [8] */
+  border-radius: 4px;
+  /* [8] */
+}
+
+.btn, .btn:hover {
+  text-decoration: none;
+  /* [9] */
+}
+.btn:active, .btn:focus {
+  outline: none;
+}
+
+/*------------------------------------*\
+    $SIZES
+\*------------------------------------*/
+/**
+ * Button size modifiers.
+ *
+ * These all follow the same sizing rules as above; text is 1em, space around it
+ * remains uniform.
+ */
+.btn--small {
+  padding-right: 0.5em;
+  padding-left: 0.5em;
+  line-height: 2;
+}
+
+.btn--large {
+  padding-right: 1.5em;
+  padding-left: 1.5em;
+  line-height: 4;
+}
+
+.btn--huge {
+  padding-right: 2em;
+  padding-left: 2em;
+  line-height: 5;
+}
+
+/**
+ * These buttons will fill the entirety of their container.
+ *
+ * 1. Remove padding so that widths and paddings donÔÇÖt conflict.
+ */
+.btn--full {
+  width: 100%;
+  padding-right: 0;
+  /* [1] */
+  padding-left: 0;
+  /* [1] */
+  text-align: center;
+}
+
+/*------------------------------------*\
+    $FONT-SIZES
+\*------------------------------------*/
+/**
+ * Button font-size modifiers.
+ */
+.btn--alpha {
+  font-size: 3rem;
+}
+
+.btn--beta {
+  font-size: 2rem;
+}
+
+.btn--gamma {
+  font-size: 1rem;
+}
+
+/**
+ * Make the button inherit sizing from its parent.
+ */
+.btn--natural {
+  vertical-align: baseline;
+  font-size: inherit;
+  line-height: inherit;
+  padding-right: 0.5em;
+  padding-left: 0.5em;
+}
+
+/*------------------------------------*\
+    $FUNCTIONS
+\*------------------------------------*/
+/**
+ * Button function modifiers.
+ */
+/**
+ * Positive actions; e.g. sign in, purchase, submit, etc.
+ */
+.btn--positive {
+  background-color: #4a993e;
+  color: #fff;
+}
+
+/**
+ * Negative actions; e.g. close account, delete photo, remove friend, etc.
+ */
+.btn--negative {
+  background-color: #b33630;
+  color: #fff;
+}
+
+/**
+ * Inactive, disabled buttons.
+ * 
+ * 1. Make the button look like normal text when hovered.
+ */
+.btn--inactive,
+.btn--inactive:hover,
+.btn--inactive:active,
+.btn--inactive:focus {
+  background-color: #dddddd;
+  color: #777;
+  cursor: text;
+  /* [1] */
+}
+
+/*------------------------------------*\
+    $STYLES
+\*------------------------------------*/
+/**
+ * Button style modifiers.
+ *
+ * 1. Use an overly-large number to ensure completely rounded, pill-like ends.
+ */
+.btn--soft {
+  border-radius: 200px;
+  /* [1] */
+}
+
+.btn--hard {
+  border-radius: 0;
+}
+
+/*------------------------------------*\
+    $LOZENGES
+\*------------------------------------*/
+/**
+ * Create pill- and lozenge-like runs of text, e.g.:
+ *
+   <p>This <span class=pill>here</span> is a pill!</p>
+ *
+   <p>This <span class=loz>here</span> is also a lozenge!</p>
+ *
+ * Pills have fully rounded ends, lozenges have only their corners rounded.
+ *
+ * Demo: jsfiddle.net/inuitcss/N3pGm
+ *
+ */
+.pill, .loz {
+  display: inline-block;
+  /**
+   * These numbers set in ems mean that, at its narrowest, a lozenge will be
+   * the same width as the `line-height` set on the `html` element.
+   * This allows us to use the `.loz` in almost any `font-size` we wish.
+   */
+  min-width: 1.0em;
+  padding-right: 0.25em;
+  padding-left: 0.25em;
+  /* =1.50em */
+  text-align: center;
+  background-color: #cccccc;
+  color: #fff;
+  /* Override this color in your theme stylesheet */
+  /**
+   * Normally weÔÇÖd use border-radius:100%; but instead here we just use an
+   * overly large number; `border-radius:100%;` would create an oval on
+   * non-square elements whereas we just want to round the ends of an element.
+   */
+  border-radius: 100px;
+}
+
+.loz {
+  border-radius: 4px;
+}
+
+/*------------------------------------*\
+    $RULES
+\*------------------------------------*/
+/**
+ * Horizontal rules, extend `hr`.
+ *
+ * Demo: jsfiddle.net/inuitcss/L6GuZ
+ *
+ */
+.rule {
+  color: #cccccc;
+  border: none;
+  border-bottom-width: 1px;
+  border-bottom-style: solid;
+  margin-bottom: 23px;
+  margin-bottom: 1.4375rem;
+}
+
+/**
+ * Dotted rules
+ */
+.rule--dotted {
+  border-bottom-style: dotted;
+}
+
+/**
+ * Dashed rules
+ */
+.rule--dashed {
+  border-bottom-style: dashed;
+}
+
+/**
+ * Ornamental rules. Places a ┬º over the rule.
+ */
+.rule--ornament {
+  position: relative;
+  /**
+  * Pass in an arbitrary ornament though a data attribute, e.g.:
+  *
+    <hr class="rule  rule--ornament" data-ornament="!">
+  *
+  */
+}
+.rule--ornament:after {
+  content: "\00A7";
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  line-height: 0;
+  text-align: center;
+}
+.rule--ornament[data-ornament]:after {
+  content: attr(data-ornament);
+}
+
+/*------------------------------------*\
+    $STATS
+\*------------------------------------*/
+ /**
+  * Simple object to display keyÔÇôvalue statistic-like information, e.g.:
+  *
+    <div class=stat-group>
+        <dl class=stat>
+            <dt class=stat__title>Tweets</dt>
+            <dd class=stat__value>27,740</dd>
+        </dl>
+
+        <dl class=stat>
+            <dt class=stat__title>Following</dt>
+            <dd class=stat__value>11,529</dd>
+        </dl>
+
+        <dl class=stat>
+            <dt class=stat__title>Followers</dt>
+            <dd class=stat__value>12,105</dd>
+        </dl>
+    </div>
+  *
+  * Demo: jsfiddle.net/inuitcss/Bpwu6
+  *
+  */
+.stat-group {
+  margin-left: -24px;
+}
+
+.stat {
+  float: left;
+  margin-left: 24px;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: -moz-flex;
+  display: flex;
+  -webkit-flex-direction: column;
+  -moz-flex-direction: column;
+  -ms-flex-direction: column;
+  -o-flex-direction: column;
+  flex-direction: column;
+}
+
+.stat__title {
+  -webkit-order: 2;
+  -moz-order: 2;
+  -ms-order: 2;
+  -o-order: 2;
+  order: 2;
+  -ms-flex-order: 2;
+}
+
+.stat__value {
+  margin-left: 0;
+  -webkit-order: 1;
+  -moz-order: 1;
+  -ms-order: 1;
+  -o-order: 1;
+  order: 1;
+  -ms-flex-order: 1;
+}
+
+/*------------------------------------*\
+    $GREYBOX
+\*------------------------------------*/
+/**
+ * Quickly throw together greybox wireframes. Use in conjunction with other
+ * inuit.css objects to create simple greybox prototypes, e.g.:
+ *
+   <div class="island  greybox  greybox--medium">Header</div>
+
+   <ul class="nav  nav--fit  nav--block  greybox">
+       <li><a href=#>Home</a></li>
+       <li><a href=#>About</a></li>
+       <li><a href=#>Portfolio</a></li>
+       <li><a href=#>Contact</a></li>
+   </ul>
+ *
+ * The beauty of combining the greyboxing with inuit.css objects is that any
+ * prototyping can quickly be converted into/used as production code.
+ *
+ * For a more complete prototyping framework, consider Adam WhitcroftÔÇÖs Proto:
+ * adamwhitcroft.com/proto
+ *
+ * Demo: jsfiddle.net/inuitcss/qCXfh/
+ *
+ */
+.greybox,
+.graybox {
+  font-size: 12px;
+  font-size: 0.75rem;
+  line-height: 2;
+  font-family: sans-serif;
+  text-align: center;
+  background-color: rgba(0, 0, 0, 0.2);
+  color: #fff;
+}
+
+.greybox a,
+.graybox a {
+  color: #fff;
+  text-decoration: underline;
+}
+
+/**
+ * All greyboxes will occupy 100% of their parentÔÇÖs width, but to alter their
+ * heights we apply incrementally larger line-heights:
+ */
+.greybox--small,
+.graybox--small {
+  line-height: 48px;
+}
+
+.greybox--medium,
+.graybox--medium {
+  line-height: 96px;
+}
+
+.greybox--large,
+.graybox--large {
+  line-height: 192px;
+}
+
+.greybox--huge,
+.graybox--huge {
+  line-height: 384px;
+}
+
+.greybox--gigantic,
+.graybox--gigantic {
+  line-height: 768px;
+}
+
+/**
+ * Style trumps; helper and brand classes
+ */
+/*------------------------------------*\
+    $WIDTHS
+\*------------------------------------*/
+/**
+ * Sizes in human readable format. These are used in conjunction with other
+ * objects and abstractions found in inuit.css, most commonly the grid system
+ * and faux flexbox.
+ *
+ * We have a mixin to generate our widths and their breakpoint-specific
+ * variations.
+ */
+/**
+* Whole
+*/
+.one-whole {
+  width: 100%;
+}
+
+/**
+* Halves
+*/
+.one-half, .two-quarters, .three-sixths, .four-eighths, .five-tenths, .six-twelfths {
+  width: 50%;
+}
+
+/**
+* Thirds
+*/
+.one-third, .two-sixths, .four-twelfths {
+  width: 33.333%;
+}
+
+.two-thirds, .four-sixths, .eight-twelfths {
+  width: 66.666%;
+}
+
+/**
+* Quarters
+*/
+.one-quarter, .two-eighths, .three-twelfths {
+  width: 25%;
+}
+
+.three-quarters, .six-eighths, .nine-twelfths {
+  width: 75%;
+}
+
+/**
+* Fifths
+*/
+.one-fifth, .two-tenths {
+  width: 20%;
+}
+
+.two-fifths, .four-tenths {
+  width: 40%;
+}
+
+.three-fifths, .six-tenths {
+  width: 60%;
+}
+
+.four-fifths, .eight-tenths {
+  width: 80%;
+}
+
+/**
+* Sixths
+*/
+.one-sixth, .two-twelfths {
+  width: 16.666%;
+}
+
+.five-sixths, .ten-twelfths {
+  width: 83.333%;
+}
+
+/**
+* Eighths
+*/
+.one-eighth {
+  width: 12.5%;
+}
+
+.three-eighths {
+  width: 37.5%;
+}
+
+.five-eighths {
+  width: 62.5%;
+}
+
+.seven-eighths {
+  width: 87.5%;
+}
+
+/**
+* Tenths
+*/
+.one-tenth {
+  width: 10%;
+}
+
+.three-tenths {
+  width: 30%;
+}
+
+.seven-tenths {
+  width: 70%;
+}
+
+.nine-tenths {
+  width: 90%;
+}
+
+/**
+* Twelfths
+*/
+.one-twelfth {
+  width: 8.333%;
+}
+
+.five-twelfths {
+  width: 41.666%;
+}
+
+.seven-twelfths {
+  width: 58.333%;
+}
+
+.eleven-twelfths {
+  width: 91.666%;
+}
+
+/**
+ * If you have set `$responsive` to ÔÇÿtrueÔÇÖ in `_vars.scss` then you now have
+ * access to these classes. You can define at which breakpoint youÔÇÖd like an
+ * element to be a certain size, e.g.:
+ *
+ * `<div class="g  one-quarter  lap-one-half  palm-one-whole"> ... </div>`
+ *
+ * This would create a `div` that, at ÔÇÿdesktopÔÇÖ sizes, takes up a quarter of the
+ * horizontal space, a half of that space at ÔÇÿtabletÔÇÖ sizes, and goes full width
+ * at ÔÇÿmobileÔÇÖ sizes.
+ *
+ * Demo: jsfiddle.net/inuitcss/WS4Ge
+ *
+ */
+@media only screen and (max-width: 480px) {
+  /**
+  * Whole
+  */
+  .palm-one-whole {
+    width: 100%;
+  }
+
+  /**
+  * Halves
+  */
+  .palm-one-half, .palm-two-quarters, .palm-three-sixths, .palm-four-eighths, .palm-five-tenths, .palm-six-twelfths {
+    width: 50%;
+  }
+
+  /**
+  * Thirds
+  */
+  .palm-one-third, .palm-two-sixths, .palm-four-twelfths {
+    width: 33.333%;
+  }
+
+  .palm-two-thirds, .palm-four-sixths, .palm-eight-twelfths {
+    width: 66.666%;
+  }
+
+  /**
+  * Quarters
+  */
+  .palm-one-quarter, .palm-two-eighths, .palm-three-twelfths {
+    width: 25%;
+  }
+
+  .palm-three-quarters, .palm-six-eighths, .palm-nine-twelfths {
+    width: 75%;
+  }
+
+  /**
+  * Fifths
+  */
+  .palm-one-fifth, .palm-two-tenths {
+    width: 20%;
+  }
+
+  .palm-two-fifths, .palm-four-tenths {
+    width: 40%;
+  }
+
+  .palm-three-fifths, .palm-six-tenths {
+    width: 60%;
+  }
+
+  .palm-four-fifths, .palm-eight-tenths {
+    width: 80%;
+  }
+
+  /**
+  * Sixths
+  */
+  .palm-one-sixth, .palm-two-twelfths {
+    width: 16.666%;
+  }
+
+  .palm-five-sixths, .palm-ten-twelfths {
+    width: 83.333%;
+  }
+
+  /**
+  * Eighths
+  */
+  .palm-one-eighth {
+    width: 12.5%;
+  }
+
+  .palm-three-eighths {
+    width: 37.5%;
+  }
+
+  .palm-five-eighths {
+    width: 62.5%;
+  }
+
+  .palm-seven-eighths {
+    width: 87.5%;
+  }
+
+  /**
+  * Tenths
+  */
+  .palm-one-tenth {
+    width: 10%;
+  }
+
+  .palm-three-tenths {
+    width: 30%;
+  }
+
+  .palm-seven-tenths {
+    width: 70%;
+  }
+
+  .palm-nine-tenths {
+    width: 90%;
+  }
+
+  /**
+  * Twelfths
+  */
+  .palm-one-twelfth {
+    width: 8.333%;
+  }
+
+  .palm-five-twelfths {
+    width: 41.666%;
+  }
+
+  .palm-seven-twelfths {
+    width: 58.333%;
+  }
+
+  .palm-eleven-twelfths {
+    width: 91.666%;
+  }
+}
+@media only screen and (min-width: 481px) and (max-width: 1023px) {
+  /**
+  * Whole
+  */
+  .lap-one-whole {
+    width: 100%;
+  }
+
+  /**
+  * Halves
+  */
+  .lap-one-half, .lap-two-quarters, .lap-three-sixths, .lap-four-eighths, .lap-five-tenths, .lap-six-twelfths {
+    width: 50%;
+  }
+
+  /**
+  * Thirds
+  */
+  .lap-one-third, .lap-two-sixths, .lap-four-twelfths {
+    width: 33.333%;
+  }
+
+  .lap-two-thirds, .lap-four-sixths, .lap-eight-twelfths {
+    width: 66.666%;
+  }
+
+  /**
+  * Quarters
+  */
+  .lap-one-quarter, .lap-two-eighths, .lap-three-twelfths {
+    width: 25%;
+  }
+
+  .lap-three-quarters, .lap-six-eighths, .lap-nine-twelfths {
+    width: 75%;
+  }
+
+  /**
+  * Fifths
+  */
+  .lap-one-fifth, .lap-two-tenths {
+    width: 20%;
+  }
+
+  .lap-two-fifths, .lap-four-tenths {
+    width: 40%;
+  }
+
+  .lap-three-fifths, .lap-six-tenths {
+    width: 60%;
+  }
+
+  .lap-four-fifths, .lap-eight-tenths {
+    width: 80%;
+  }
+
+  /**
+  * Sixths
+  */
+  .lap-one-sixth, .lap-two-twelfths {
+    width: 16.666%;
+  }
+
+  .lap-five-sixths, .lap-ten-twelfths {
+    width: 83.333%;
+  }
+
+  /**
+  * Eighths
+  */
+  .lap-one-eighth {
+    width: 12.5%;
+  }
+
+  .lap-three-eighths {
+    width: 37.5%;
+  }
+
+  .lap-five-eighths {
+    width: 62.5%;
+  }
+
+  .lap-seven-eighths {
+    width: 87.5%;
+  }
+
+  /**
+  * Tenths
+  */
+  .lap-one-tenth {
+    width: 10%;
+  }
+
+  .lap-three-tenths {
+    width: 30%;
+  }
+
+  .lap-seven-tenths {
+    width: 70%;
+  }
+
+  .lap-nine-tenths {
+    width: 90%;
+  }
+
+  /**
+  * Twelfths
+  */
+  .lap-one-twelfth {
+    width: 8.333%;
+  }
+
+  .lap-five-twelfths {
+    width: 41.666%;
+  }
+
+  .lap-seven-twelfths {
+    width: 58.333%;
+  }
+
+  .lap-eleven-twelfths {
+    width: 91.666%;
+  }
+}
+@media only screen and (min-width: 481px) {
+  /**
+  * Whole
+  */
+  .lap-and-up-one-whole {
+    width: 100%;
+  }
+
+  /**
+  * Halves
+  */
+  .lap-and-up-one-half, .lap-and-up-two-quarters, .lap-and-up-three-sixths, .lap-and-up-four-eighths, .lap-and-up-five-tenths, .lap-and-up-six-twelfths {
+    width: 50%;
+  }
+
+  /**
+  * Thirds
+  */
+  .lap-and-up-one-third, .lap-and-up-two-sixths, .lap-and-up-four-twelfths {
+    width: 33.333%;
+  }
+
+  .lap-and-up-two-thirds, .lap-and-up-four-sixths, .lap-and-up-eight-twelfths {
+    width: 66.666%;
+  }
+
+  /**
+  * Quarters
+  */
+  .lap-and-up-one-quarter, .lap-and-up-two-eighths, .lap-and-up-three-twelfths {
+    width: 25%;
+  }
+
+  .lap-and-up-three-quarters, .lap-and-up-six-eighths, .lap-and-up-nine-twelfths {
+    width: 75%;
+  }
+
+  /**
+  * Fifths
+  */
+  .lap-and-up-one-fifth, .lap-and-up-two-tenths {
+    width: 20%;
+  }
+
+  .lap-and-up-two-fifths, .lap-and-up-four-tenths {
+    width: 40%;
+  }
+
+  .lap-and-up-three-fifths, .lap-and-up-six-tenths {
+    width: 60%;
+  }
+
+  .lap-and-up-four-fifths, .lap-and-up-eight-tenths {
+    width: 80%;
+  }
+
+  /**
+  * Sixths
+  */
+  .lap-and-up-one-sixth, .lap-and-up-two-twelfths {
+    width: 16.666%;
+  }
+
+  .lap-and-up-five-sixths, .lap-and-up-ten-twelfths {
+    width: 83.333%;
+  }
+
+  /**
+  * Eighths
+  */
+  .lap-and-up-one-eighth {
+    width: 12.5%;
+  }
+
+  .lap-and-up-three-eighths {
+    width: 37.5%;
+  }
+
+  .lap-and-up-five-eighths {
+    width: 62.5%;
+  }
+
+  .lap-and-up-seven-eighths {
+    width: 87.5%;
+  }
+
+  /**
+  * Tenths
+  */
+  .lap-and-up-one-tenth {
+    width: 10%;
+  }
+
+  .lap-and-up-three-tenths {
+    width: 30%;
+  }
+
+  .lap-and-up-seven-tenths {
+    width: 70%;
+  }
+
+  .lap-and-up-nine-tenths {
+    width: 90%;
+  }
+
+  /**
+  * Twelfths
+  */
+  .lap-and-up-one-twelfth {
+    width: 8.333%;
+  }
+
+  .lap-and-up-five-twelfths {
+    width: 41.666%;
+  }
+
+  .lap-and-up-seven-twelfths {
+    width: 58.333%;
+  }
+
+  .lap-and-up-eleven-twelfths {
+    width: 91.666%;
+  }
+}
+@media only screen and (max-width: 1023px) {
+  /**
+  * Whole
+  */
+  .portable-one-whole {
+    width: 100%;
+  }
+
+  /**
+  * Halves
+  */
+  .portable-one-half, .portable-two-quarters, .portable-three-sixths, .portable-four-eighths, .portable-five-tenths, .portable-six-twelfths {
+    width: 50%;
+  }
+
+  /**
+  * Thirds
+  */
+  .portable-one-third, .portable-two-sixths, .portable-four-twelfths {
+    width: 33.333%;
+  }
+
+  .portable-two-thirds, .portable-four-sixths, .portable-eight-twelfths {
+    width: 66.666%;
+  }
+
+  /**
+  * Quarters
+  */
+  .portable-one-quarter, .portable-two-eighths, .portable-three-twelfths {
+    width: 25%;
+  }
+
+  .portable-three-quarters, .portable-six-eighths, .portable-nine-twelfths {
+    width: 75%;
+  }
+
+  /**
+  * Fifths
+  */
+  .portable-one-fifth, .portable-two-tenths {
+    width: 20%;
+  }
+
+  .portable-two-fifths, .portable-four-tenths {
+    width: 40%;
+  }
+
+  .portable-three-fifths, .portable-six-tenths {
+    width: 60%;
+  }
+
+  .portable-four-fifths, .portable-eight-tenths {
+    width: 80%;
+  }
+
+  /**
+  * Sixths
+  */
+  .portable-one-sixth, .portable-two-twelfths {
+    width: 16.666%;
+  }
+
+  .portable-five-sixths, .portable-ten-twelfths {
+    width: 83.333%;
+  }
+
+  /**
+  * Eighths
+  */
+  .portable-one-eighth {
+    width: 12.5%;
+  }
+
+  .portable-three-eighths {
+    width: 37.5%;
+  }
+
+  .portable-five-eighths {
+    width: 62.5%;
+  }
+
+  .portable-seven-eighths {
+    width: 87.5%;
+  }
+
+  /**
+  * Tenths
+  */
+  .portable-one-tenth {
+    width: 10%;
+  }
+
+  .portable-three-tenths {
+    width: 30%;
+  }
+
+  .portable-seven-tenths {
+    width: 70%;
+  }
+
+  .portable-nine-tenths {
+    width: 90%;
+  }
+
+  /**
+  * Twelfths
+  */
+  .portable-one-twelfth {
+    width: 8.333%;
+  }
+
+  .portable-five-twelfths {
+    width: 41.666%;
+  }
+
+  .portable-seven-twelfths {
+    width: 58.333%;
+  }
+
+  .portable-eleven-twelfths {
+    width: 91.666%;
+  }
+}
+@media only screen and (min-width: 1024px) {
+  /**
+  * Whole
+  */
+  .desk-one-whole {
+    width: 100%;
+  }
+
+  /**
+  * Halves
+  */
+  .desk-one-half, .desk-two-quarters, .desk-three-sixths, .desk-four-eighths, .desk-five-tenths, .desk-six-twelfths {
+    width: 50%;
+  }
+
+  /**
+  * Thirds
+  */
+  .desk-one-third, .desk-two-sixths, .desk-four-twelfths {
+    width: 33.333%;
+  }
+
+  .desk-two-thirds, .desk-four-sixths, .desk-eight-twelfths {
+    width: 66.666%;
+  }
+
+  /**
+  * Quarters
+  */
+  .desk-one-quarter, .desk-two-eighths, .desk-three-twelfths {
+    width: 25%;
+  }
+
+  .desk-three-quarters, .desk-six-eighths, .desk-nine-twelfths {
+    width: 75%;
+  }
+
+  /**
+  * Fifths
+  */
+  .desk-one-fifth, .desk-two-tenths {
+    width: 20%;
+  }
+
+  .desk-two-fifths, .desk-four-tenths {
+    width: 40%;
+  }
+
+  .desk-three-fifths, .desk-six-tenths {
+    width: 60%;
+  }
+
+  .desk-four-fifths, .desk-eight-tenths {
+    width: 80%;
+  }
+
+  /**
+  * Sixths
+  */
+  .desk-one-sixth, .desk-two-twelfths {
+    width: 16.666%;
+  }
+
+  .desk-five-sixths, .desk-ten-twelfths {
+    width: 83.333%;
+  }
+
+  /**
+  * Eighths
+  */
+  .desk-one-eighth {
+    width: 12.5%;
+  }
+
+  .desk-three-eighths {
+    width: 37.5%;
+  }
+
+  .desk-five-eighths {
+    width: 62.5%;
+  }
+
+  .desk-seven-eighths {
+    width: 87.5%;
+  }
+
+  /**
+  * Tenths
+  */
+  .desk-one-tenth {
+    width: 10%;
+  }
+
+  .desk-three-tenths {
+    width: 30%;
+  }
+
+  .desk-seven-tenths {
+    width: 70%;
+  }
+
+  .desk-nine-tenths {
+    width: 90%;
+  }
+
+  /**
+  * Twelfths
+  */
+  .desk-one-twelfth {
+    width: 8.333%;
+  }
+
+  .desk-five-twelfths {
+    width: 41.666%;
+  }
+
+  .desk-seven-twelfths {
+    width: 58.333%;
+  }
+
+  .desk-eleven-twelfths {
+    width: 91.666%;
+  }
+}
+/**
+ * If you have set the additional `$responsive-extra` variable to ÔÇÿtrueÔÇÖ in
+ * `_vars.scss` then you now have access to the following class available to
+ * accomodate much larger screen resolutions.
+ */
+/* endif */
+/*------------------------------------*\
+    $PUSH
+\*------------------------------------*/
+/**
+ * Push classes, to move grid items over to the right by certain amounts.
+ */
+/*------------------------------------*\
+    $PULL
+\*------------------------------------*/
+/**
+ * Pull classes, to move grid items over to the right by certain amounts.
+ */
+/*------------------------------------*\
+    $BRAND
+\*------------------------------------*/
+/**
+ * `.brand` is a quick and simple way to apply your brand face and/or color to
+ * any element using a handy helper class.
+ */
+.brand {
+  font-family: "Helvetica Neue", sans-serif!important;
+  color: #3f89c1!important;
+}
+
+.brand-face {
+  font-family: "Helvetica Neue", sans-serif!important;
+}
+
+.brand-color,
+.brand-colour {
+  color: #3f89c1!important;
+}
+
+/*------------------------------------*\
+    $HELPER
+\*------------------------------------*/
+/**
+ * A series of helper classes to use arbitrarily. Only use a helper class if an
+ * element/component doesnÔÇÖt already have a class to which you could apply this
+ * styling, e.g. if you need to float `.main-nav` left then add `float:left;` to
+ * that ruleset as opposed to adding the `.float--left` class to the markup.
+ *
+ * A lot of these classes carry `!important` as you will always want them to win
+ * out over other selectors.
+ */
+/**
+ * Add/remove floats
+ */
+.float--right {
+  float: right !important;
+}
+
+.float--left {
+  float: left !important;
+}
+
+.float--none {
+  float: none !important;
+}
+
+/**
+ * Text alignment
+ */
+.text--left {
+  text-align: left  !important;
+}
+
+.text--center {
+  text-align: center !important;
+}
+
+.text--right {
+  text-align: right !important;
+}
+
+/**
+ * Font weights
+ */
+.weight--light {
+  font-weight: 300 !important;
+}
+
+.weight--normal {
+  font-weight: 400 !important;
+}
+
+.weight--semibold {
+  font-weight: 600 !important;
+}
+
+/**
+ * Add/remove margins
+ */
+.push {
+  margin: 24px !important;
+}
+
+.push--top {
+  margin-top: 24px !important;
+}
+
+.push--right {
+  margin-right: 24px !important;
+}
+
+.push--bottom {
+  margin-bottom: 24px !important;
+}
+
+.push--left {
+  margin-left: 24px !important;
+}
+
+.push--ends {
+  margin-top: 24px !important;
+  margin-bottom: 24px !important;
+}
+
+.push--sides {
+  margin-right: 24px !important;
+  margin-left: 24px !important;
+}
+
+.push-half {
+  margin: 12px !important;
+}
+
+.push-half--top {
+  margin-top: 12px !important;
+}
+
+.push-half--right {
+  margin-right: 12px !important;
+}
+
+.push-half--bottom {
+  margin-bottom: 12px !important;
+}
+
+.push-half--left {
+  margin-left: 12px !important;
+}
+
+.push-half--ends {
+  margin-top: 12px !important;
+  margin-bottom: 12px !important;
+}
+
+.push-half--sides {
+  margin-right: 12px !important;
+  margin-left: 12px !important;
+}
+
+.flush {
+  margin: 0 !important;
+}
+
+.flush--top {
+  margin-top: 0 !important;
+}
+
+.flush--right {
+  margin-right: 0 !important;
+}
+
+.flush--bottom {
+  margin-bottom: 0 !important;
+}
+
+.flush--left {
+  margin-left: 0 !important;
+}
+
+.flush--ends {
+  margin-top: 0 !important;
+  margin-bottom: 0 !important;
+}
+
+.flush--sides {
+  margin-right: 0 !important;
+  margin-left: 0 !important;
+}
+
+/**
+ * Add/remove paddings
+ */
+.soft {
+  padding: 24px !important;
+}
+
+.soft--top {
+  padding-top: 24px !important;
+}
+
+.soft--right {
+  padding-right: 24px !important;
+}
+
+.soft--bottom {
+  padding-bottom: 24px !important;
+}
+
+.soft--left {
+  padding-left: 24px !important;
+}
+
+.soft--ends {
+  padding-top: 24px !important;
+  padding-bottom: 24px !important;
+}
+
+.soft--sides {
+  padding-right: 24px !important;
+  padding-left: 24px !important;
+}
+
+.soft-half {
+  padding: 12px !important;
+}
+
+.soft-half--top {
+  padding-top: 12px !important;
+}
+
+.soft-half--right {
+  padding-right: 12px !important;
+}
+
+.soft-half--bottom {
+  padding-bottom: 12px !important;
+}
+
+.soft-half--left {
+  padding-left: 12px !important;
+}
+
+.soft-half--ends {
+  padding-top: 12px !important;
+  padding-bottom: 12px !important;
+}
+
+.soft-half--sides {
+  padding-right: 12px !important;
+  padding-left: 12px !important;
+}
+
+.hard {
+  padding: 0 !important;
+}
+
+.hard--top {
+  padding-top: 0 !important;
+}
+
+.hard--right {
+  padding-right: 0 !important;
+}
+
+.hard--bottom {
+  padding-bottom: 0 !important;
+}
+
+.hard--left {
+  padding-left: 0 !important;
+}
+
+.hard--ends {
+  padding-top: 0 !important;
+  padding-bottom: 0 !important;
+}
+
+.hard--sides {
+  padding-right: 0 !important;
+  padding-left: 0 !important;
+}
+
+/**
+ * Pull items full width of `.island` parents.
+ */
+.full-bleed {
+  margin-right: -24px !important;
+  margin-left: -24px !important;
+}
+.islet .full-bleed {
+  margin-right: -12px !important;
+  margin-left: -12px !important;
+}
+
+/**
+ * Add a help cursor to any element that gives the user extra information on
+ * `:hover`.
+ */
+.informative {
+  cursor: help !important;
+}
+
+/**
+ * Mute an object by reducing its opacity.
+ */
+.muted {
+  opacity: 0.5 !important;
+  filter: alpha(opacity=50) !important;
+}
+
+/**
+ * Align items to the right where they imply progression/movement forward, e.g.:
+ *
+   <p class=proceed><a href=#>Read more...</a></p>
+ *
+ */
+.proceed {
+  text-align: right !important;
+}
+
+/**
+ * Add a right-angled quote to links that imply movement, e.g.:
+ *
+   <a href=# class=go>Read more</a>
+ *
+ */
+.go:after {
+  content: "\00A0" "\00BB" !important;
+}
+
+/**
+ * Apply capital case to an element (usually a `strong`).
+ */
+.caps {
+  text-transform: uppercase !important;
+}
+
+/**
+ * Hide content off-screen without resorting to `display:none;`, also provide
+ * breakpoint specific hidden elements.
+ */
+.accessibility,
+.visuallyhidden {
+  border: 0 !important;
+  clip: rect(0 0 0 0) !important;
+  height: 1px !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  padding: 0 !important;
+  position: absolute !important;
+  width: 1px !important;
+}
+
+@media only screen and (max-width: 480px) {
+  .accessibility--palm,
+  .visuallyhidden--palm {
+    border: 0 !important;
+    clip: rect(0 0 0 0) !important;
+    height: 1px !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    padding: 0 !important;
+    position: absolute !important;
+    width: 1px !important;
+  }
+}
+@media only screen and (min-width: 481px) and (max-width: 1023px) {
+  .accessibility--lap,
+  .visuallyhidden--lap {
+    border: 0 !important;
+    clip: rect(0 0 0 0) !important;
+    height: 1px !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    padding: 0 !important;
+    position: absolute !important;
+    width: 1px !important;
+  }
+}
+@media only screen and (min-width: 481px) {
+  .accessibility--lap-and-up,
+  .visuallyhidden--lap-and-up {
+    border: 0 !important;
+    clip: rect(0 0 0 0) !important;
+    height: 1px !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    padding: 0 !important;
+    position: absolute !important;
+    width: 1px !important;
+  }
+}
+@media only screen and (max-width: 1023px) {
+  .accessibility--portable,
+  .visuallyhidden--portable {
+    border: 0 !important;
+    clip: rect(0 0 0 0) !important;
+    height: 1px !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    padding: 0 !important;
+    position: absolute !important;
+    width: 1px !important;
+  }
+}
+@media only screen and (min-width: 1024px) {
+  .accessibility--desk,
+  .visuallyhidden--desk {
+    border: 0 !important;
+    clip: rect(0 0 0 0) !important;
+    height: 1px !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    padding: 0 !important;
+    position: absolute !important;
+    width: 1px !important;
+  }
+}
+@media only screen and (min-width: 1200px) {
+  .accessibility--desk-wide,
+  .visuallyhidden--desk-wide {
+    border: 0 !important;
+    clip: rect(0 0 0 0) !important;
+    height: 1px !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    padding: 0 !important;
+    position: absolute !important;
+    width: 1px !important;
+  }
+}
+/* endif */
+/**
+ * She’s all yours, cap’n... Begin importing your stuff here.
+ */
+/*
+ * Image replacement from https://github.com/h5bp/html5-boilerplate
+ */
+.ir {
+  background-color: transparent;
+  border: 0;
+  overflow: hidden;
+  /* IE 6/7 fallback */
+  *text-indent: -9999px;
+}
+
+.ir:before {
+  content: "";
+  display: block;
+  width: 0;
+  height: 150%;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p {
+  color: #2f4054;
+}
+
+a {
+  color: #3f89c1;
+}
+
+body {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 1.5em;
+}
+
+.masthead {
+  position: relative;
+}
+
+.masthead__logo {
+  display: inline-block;
+  width: 7.77778em;
+  height: 3.61111em;
+  background: url(/img/content/logo.png) no-repeat;
+}
+
+.masthead__text {
+  display: block;
+}
+
+@media screen and (min-width: 570px) {
+  .masthead__text {
+    position: absolute;
+    top: 1.30556em;
+    left: 7.91667em;
+  }
+}
+.section-title {
+  margin-top: 2em;
+  border-bottom: 1px solid #cccccc;
+}
+.section-title:first-child {
+  margin-top: 0;
+}
+
+.test-arrow {
+  display: inline-block;
+  width: 6.25em;
+  height: 6.25em;
+  margin: 0 0.9375em 0.9375em 0;
+  padding-top: 2.5em;
+  background-color: #3f89c1;
+  color: white;
+  text-align: center;
+}
+
+.test-arrow--top-left:before {
+  border-bottom-color: #3f89c1 !important;
+}
+.test-arrow--top-left:after {
+  border-bottom-color: #3f89c1 !important;
+}
+
+.test-arrow--top-right:before {
+  border-bottom-color: #3f89c1 !important;
+}
+.test-arrow--top-right:after {
+  border-bottom-color: #3f89c1 !important;
+}
+
+.test-arrow--top-center:before {
+  border-bottom-color: #3f89c1 !important;
+}
+.test-arrow--top-center:after {
+  border-bottom-color: #3f89c1 !important;
+}
+
+.test-arrow--right-top:before {
+  border-left-color: #3f89c1 !important;
+}
+.test-arrow--right-top:after {
+  border-left-color: #3f89c1 !important;
+}
+
+.test-arrow--right-center:before {
+  border-left-color: #3f89c1 !important;
+}
+.test-arrow--right-center:after {
+  border-left-color: #3f89c1 !important;
+}
+
+.test-arrow--right-bottom:before {
+  border-left-color: #3f89c1 !important;
+}
+.test-arrow--right-bottom:after {
+  border-left-color: #3f89c1 !important;
+}
+
+.test-arrow--bottom-left:before {
+  border-top-color: #3f89c1 !important;
+}
+.test-arrow--bottom-left:after {
+  border-top-color: #3f89c1 !important;
+}
+
+.test-arrow--bottom-center:before {
+  border-top-color: #3f89c1 !important;
+}
+.test-arrow--bottom-center:after {
+  border-top-color: #3f89c1 !important;
+}
+
+.test-arrow--bottom-right:before {
+  border-top-color: #3f89c1 !important;
+}
+.test-arrow--bottom-right:after {
+  border-top-color: #3f89c1 !important;
+}
+
+.test-arrow--left-top:before {
+  border-right-color: #3f89c1 !important;
+}
+.test-arrow--left-top:after {
+  border-right-color: #3f89c1 !important;
+}
+
+.test-arrow--left-center:before {
+  border-right-color: #3f89c1 !important;
+}
+.test-arrow--left-center:after {
+  border-right-color: #3f89c1 !important;
+}
+
+.test-arrow--left-bottom:before {
+  border-right-color: #3f89c1 !important;
+}
+.test-arrow--left-bottom:after {
+  border-right-color: #3f89c1 !important;
+}
+
+.btn-demo {
+  margin-bottom: 0.5em;
+  color: white;
+}
+
+.bleed-demo {
+  background-color: #3f89c1;
+  color: white;
+}
+
+.flexbox-demo {
+  margin-bottom: 1em;
+  border: 1px solid;
+}
+
+.float-demo {
+  width: 6.25em;
+}
+.float-demo + hr {
+  clear: both;
+}
+
+.margins-demo,
+.paddings-demo {
+  display: inline-block;
+  margin-bottom: 0.625em;
+  background-color: orange;
+  text-align: center;
+}
+
+.margins-demo__item,
+.paddings-demo__item {
+  display: inline-block;
+  width: 6.25em;
+  height: 6.25em;
+  vertical-align: top;
+  background: #ace;
+}
+
+.margins-demo--full-margin {
+  margin: 24px;
+}
+
+.paddings-demo--full-padding {
+  padding: 24px;
+}
+
+.grid-demo {
+  border: 1px solid #666666;
+}
+
+/* .triangle-one-demo,
+.triangle-two-demo,
+.triangle-three-demo {
+	display: inline-block;
+	//margin-right: em(20px);
+}
+
+.triangle-one-demo {
+	@include arrow(top, left, red);
+}
+.triangle-two-demo {
+	@include arrow(bottom, center, red, black);
+}
+.triangle-three-demo {
+	background-color:#BADA55;
+    border:1px solid #ACE;
+    @include arrow(top, left, #BADA55, #ACE);
+} */

--- a/css/ui/demo.scss
+++ b/css/ui/demo.scss
@@ -1,0 +1,152 @@
+
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p{
+	color:$brand-color;
+}
+a{
+	color:$brand-color;
+}
+
+body{
+	max-width:1100px;
+	margin:0 auto;
+	padding:em(24px);
+}
+
+//Masthead
+.masthead{
+	position:relative;
+}
+.masthead__logo{
+	display:inline-block;
+	width:em(280px, $h1-size);
+	height:em(130px,$h1-size);
+	background:url(/img/content/logo.png) no-repeat;
+}
+.masthead__text{
+	display:block;
+}
+
+@media screen and (min-width:570px){
+	.masthead__text{
+		position:absolute;
+		top:em(47px, $h1-size);
+		left:em(285px, $h1-size);
+	}
+}
+
+.section-title{
+	margin-top:2em;
+	border-bottom:1px solid #ccc;
+	&:first-child{
+		margin-top:0;
+	}
+}
+
+//Arrows
+.test-arrow{
+	display:inline-block;
+	width:em(100px);
+	height:em(100px);
+	margin:0 em(15px) em(15px) 0;
+	padding-top:em(40px);
+	background-color:$brand-color;
+	color:#fff;
+	text-align:center;
+}
+.test-arrow--top-left{
+	@include arrow(top, left, $brand-color);
+}
+.test-arrow--top-right{
+	@include arrow(top, right, $brand-color);
+}
+.test-arrow--top-center{
+	@include arrow(top, center, $brand-color);
+}
+.test-arrow--right-top{
+	@include arrow(right, top, $brand-color);
+}
+.test-arrow--right-center{
+	@include arrow(right, center, $brand-color);
+}
+.test-arrow--right-bottom{
+	@include arrow(right, bottom, $brand-color);
+}
+.test-arrow--bottom-left{
+	@include arrow(bottom, left, $brand-color);
+}
+.test-arrow--bottom-center{
+	@include arrow(bottom, center, $brand-color);
+}
+.test-arrow--bottom-right{
+	@include arrow(bottom, right, $brand-color);
+}
+.test-arrow--left-top{
+	@include arrow(left, top, $brand-color);
+}
+.test-arrow--left-center{
+	@include arrow(left, center, $brand-color);
+}
+.test-arrow--left-bottom{
+	@include arrow(left, bottom, $brand-color);
+}
+
+//Beautons
+.btn-demo{
+	margin-bottom:0.5em;
+	color:#fff;
+}
+
+//Full Bleed
+.bleed-demo{
+	background-color:$brand-color;
+	color:#fff;
+}
+
+//Flexbox
+.flexbox-demo{
+	margin-bottom: 1em;
+	border:1px solid ;
+}
+
+//Floats
+.float-demo{
+	width:em(100px);
+	+ hr {
+		clear:both;
+	}
+}
+
+//Margins/Paddings Demo
+.margins-demo,
+.paddings-demo{
+	display:inline-block;
+	margin-bottom:em(10px);
+	background-color:orange;
+	text-align:center;
+}
+.margins-demo__item,
+.paddings-demo__item{
+	display:inline-block;
+	width:em(100px);
+	height:em(100px);
+	vertical-align:top;
+	background:#ace;
+}
+.margins-demo--full-margin{
+	margin:$base-spacing-unit;
+}
+.paddings-demo--full-padding{
+	padding:$base-spacing-unit;
+}
+
+//Grids
+.grid-demo{
+	border:1px solid darken(#ccc, 40%);
+}

--- a/kitchen-sink/index.html
+++ b/kitchen-sink/index.html
@@ -1,0 +1,79 @@
+---
+title: Kitchen Sink
+---
+
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset=UTF-8>
+    <title>{{ page.title }} &ndash; inuit.css &ndash; a powerful, scalable, Sass-based, BEM, OOCSS framework</title>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel=stylesheet href=/css/kitchen-sink.css>
+    <link rel="shortcut icon" href={{ site.root }}icon.png>
+    <link rel=apple-touch-icon-precomposed href={{ site.root }}icon.png>
+    <meta name=apple-mobile-web-app-title content="inuit.css">
+</head>
+
+<body>
+
+	<div class="main">
+
+		<!-- MASTHEAD -->
+		<h1 class="masthead">
+			<a href="http://www.inuitcss.com" target="_blank" class="masthead__logo ir">Inuit.css</a>
+			<span class="masthead__text">Kitchen Sink</span>
+		</h1>
+		<!-- / MASTHEAD -->
+
+		<!-- INTRO -->
+		<p class="lead">A list of <a href="http://www.inuitcss.com">Inuit.css</a> component examples. The page contains minimal styling so components are pretty much as is from Inuit. Code used from <a target="_blank" href="https://github.com/csswizardry/inuit.css/tree/v5.1.0">v5.1.0</a> branch used.</p>
+		<!-- / INTRO -->
+
+		<div class="grid">
+
+			<!-- SUBNAV -->
+			{% include kitchen-sink/subnav.html %}<!--
+
+				MAIN
+			--><div class="grid__item lap-and-up-three-quarters">
+
+				<!-- 	WHERE THE MAGIC HAPPENS -->
+				{% include kitchen-sink/objects/arrows.html %}
+				{% include kitchen-sink/objects/beautons.html %}
+				{% include kitchen-sink/objects/block-list.html %}
+				{% include kitchen-sink/objects/breadcrumb.html %}
+				{% include kitchen-sink/objects/columns.html %}
+				{% include kitchen-sink/objects/flexbox.html %}
+				{% include kitchen-sink/objects/flyout.html %}
+				{% include kitchen-sink/objects/greybox.html %}
+				{% include kitchen-sink/objects/grids.html %}
+				{% include kitchen-sink/objects/images.html %}
+				{% include kitchen-sink/objects/island.html %}
+				{% include kitchen-sink/objects/link-complex.html %}
+				{% include kitchen-sink/objects/lozenges.html %}
+				{% include kitchen-sink/objects/marginalia.html %}
+				{% include kitchen-sink/objects/matrix.html %}
+				{% include kitchen-sink/objects/media.html %}
+				{% include kitchen-sink/objects/nav.html %}
+				{% include kitchen-sink/objects/options.html %}
+				{% include kitchen-sink/objects/pagination.html %}
+				{% include kitchen-sink/objects/rule.html %}
+				{% include kitchen-sink/objects/split.html %}
+				{% include kitchen-sink/objects/stats.html %}
+				{% include kitchen-sink/objects/tables.html %}
+				{% include kitchen-sink/objects/this-or-this.html %}
+				{% include kitchen-sink/base/forms.html') %}
+				{% include kitchen-sink/base/typography.html %}
+				{% include kitchen-sink/generic/helper.html %}
+				{% include kitchen-sink/generic/mixins.html %}
+				<!-- / INUIT.CSS COMPONENTS -->
+
+			</div>
+			<!-- / MAIN -->
+
+		</div>
+	</div>
+
+</body>
+</html>


### PR DESCRIPTION
As discussed in #121 here's an examples page for review. It'll be a stopgap until we get an automated strategy using the CSS comments like [StyleDocco](http://jacobrask.github.io/styledocco/) or [KSS](http://warpspire.com/kss/)

Things to note:
- The page is at `kitchen-sink/index.html`, i.e. URL will be `/kitchen-sink/`.
- Examples are broken up into different files within `_includes/kitchen-sink/`
- I don't use the default `gh-pages` CSS styles as the example page uses Branch v5.1.0 and has a more stripped back style.
  - `css/kitchen-sink.css` includes inuit.css v5.1.0 (`.scss` not included) and some basic demo styles (see `css/ui/demo.scss`). I have left it unminified as I guess the CSS is documentation too.

If anything needs to change let me know.

Thanks,
Pat
