### PR TITLE
IE8+ Supports inline-blocks

### DIFF
--- a/objects/_nav.scss
+++ b/objects/_nav.scss
@@ -28,7 +28,6 @@
         &,
         > a{
             display:inline-block;
-           *display:inline;
             zoom:1;
         }
     }


### PR DESCRIPTION
The last release to support IE7 was v4.1.5.
