### PR TITLE
Prevent <hr> being flagged as an error by the :empty debugging selector

### DIFF
--- a/generic/_debug.scss
+++ b/generic/_debug.scss
@@ -18,7 +18,7 @@
 /**
  * Are there any empty elements in your page?
  */
-:empty{
+:empty:not(hr){
     outline:5px solid yellow;
 }
 


### PR DESCRIPTION
This commit fixes #100
