### PR TITLE
hgroup deprecated

### DIFF
--- a/base/_headings.scss
+++ b/base/_headings.scss
@@ -40,7 +40,7 @@ h6,.zeta{
  */
 .hN{
 }
-hgroup .hN{
+header .hN{
     margin-bottom:0;
 }
 


### PR DESCRIPTION
<hgroup> element deprecated (http://lists.w3.org/Archives/Public/public-html/2013Mar/0026.html) Should utilize header tag instead
