### PR TITLE
Added sprite placeholder for cleaner extending

### DIFF
--- a/objects/_sprite.scss
+++ b/objects/_sprite.scss
@@ -33,6 +33,7 @@
  *
  */
 .sprite,
+%sprite,
 .icon{
     display:inline-block;
     line-height:1;
@@ -49,7 +50,8 @@
      */
     text-align:center;
 }
-.sprite{
+.sprite,
+%sprite{
     /**
      * The typical size of most icons. Override in your theme stylesheet.
      */


### PR DESCRIPTION
I wanted to extend the sprite class for use with a pseudo CSS element but was finding it was polluting the main .sprite class. Using a placeholder fixes this issue (see: http://8gramgorilla.com/mastering-sass-extends-and-placeholders/).
