### PR TITLE
Enable easier control of borders in block lists

### DIFF
--- a/objects/_block-list.scss
+++ b/objects/_block-list.scss
@@ -29,10 +29,14 @@
     list-style:none;
     margin-left:0;
     border-top-width:1px;
+    border-bottom-width:1px;
 
     > li{
-        border-bottom-width:1px;
         padding:$half-spacing-unit;
+    }
+    
+    > li + li {
+        border-top-width:1px;
     }
 }
         .block-list__link{


### PR DESCRIPTION
Block-list's bottom borders are defined on the bottom `<li>` element. This makes it difficult to remove the top and bottom borders from a block list.

This change uses the adjacent sibling selector to limit `<li>` element's borders to 'internal borders', and defines the bottom 'external border' on the `.block-list` element like the top 'external border'.

This allows you to easily do things like this:

``` css
.block-list--noborders {
    @extend .block-list;
    border-top-width: 0;
    border-bottom-width: 0;
}
```

or 

``` css
.block-list--allborders {
    @extend .block-list;
    border-width: 1px;
}
```

Which would previously have lead to double borders (or required changing the borders of `<li>` elements).
