### PR TITLE
remove white-space:nowrap from .nav--block

### DIFF
--- a/objects/_nav.scss
+++ b/objects/_nav.scss
@@ -92,7 +92,6 @@
      */
     letter-spacing:-0.31em;
     word-spacing:-0.43em;
-    white-space:nowrap;
 
     > li{
         letter-spacing:normal;


### PR DESCRIPTION
`nowrap` breaks responsive layouts. I can't think of a situation where this behavior would be desirable.
