### PR TITLE
Remove letter/word-spacing whitespace hack from .nav and .pagination.

### DIFF
--- a/objects/_nav.scss
+++ b/objects/_nav.scss
@@ -90,13 +90,10 @@
     /**
      * Remove whitespace caused by `inline-block`.
      */
-    letter-spacing:-0.31em;
-    word-spacing:-0.43em;
-    white-space:nowrap;
+    display: inline-block;
 
     > li{
-        letter-spacing:normal;
-        word-spacing:normal;
+        float: left;
 
         > a{
             padding:$half-spacing-unit;

--- a/objects/_pagination.scss
+++ b/objects/_pagination.scss
@@ -5,8 +5,6 @@
 \*------------------------------------*/
 /**
  * Basic pagination object, extends `.nav`.
- * Requires some funky commenting to collapse any white-space caused by the
- * `display:inline-block;` rules.
  *
    <ol class="nav  pagination">
        <li class=pagination__first>First</li>
@@ -25,16 +23,11 @@
  */
 .pagination{
     text-align:center;
-    /**
-     * Remove whitespace caused by `inline-block`.
-     */
-    letter-spacing:-0.31em;
-    word-spacing:-0.43em;
+    display: inline-block;
 }
     .pagination > li{
         padding:$base-spacing-unit / 2;
-        letter-spacing:normal;
-        word-spacing:normal;
+        float: left;
     }
         .pagination > li > a{
             padding:$base-spacing-unit / 2;


### PR DESCRIPTION
In favor of items floated left in lists displayed inline-block.

I gather this hack doesn't work in Chrome since v25 when it was made optional in the grids.
It broke .nav--block and .pagination as well.
