### PR TITLE
Complete the push & pull features for the 'desk-wide' media query

### DIFF
--- a/_defaults.scss
+++ b/_defaults.scss
@@ -86,6 +86,7 @@ $lap-push:          false!default;
 $lap-and-up-push:   false!default;
 $portable-push:     false!default;
 $desk-push:         false!default;
+$desk-wide-push:    false!default;
 
 $pull:              false!default;
 /**
@@ -96,6 +97,7 @@ $lap-pull:          false!default;
 $lap-and-up-pull:   false!default;
 $portable-pull:     false!default;
 $desk-pull:         false!default;
+$desk-wide-pull:    false!default;
 
 /**
  * Tell inuit.css when breakpoints start.

--- a/generic/_pull.scss
+++ b/generic/_pull.scss
@@ -144,4 +144,19 @@
 
 }
 
+
+/**
+ * If you have set the additional `$responsive-extra` and `$desk-wide-pull`
+ * variables to ‘true’ in `_vars.scss` then you now have access to the
+ * following class available to accomodate much larger screen resolutions.
+ */
+
+@if $responsive-extra == true and $desk-wide-pull == true{
+
+@include media-query(desk-wide){
+    @include pull-setup("desk-wide-");
+}
+
+}
+
 }//endif

--- a/generic/_push.scss
+++ b/generic/_push.scss
@@ -144,4 +144,19 @@
 
 }
 
+
+/**
+ * If you have set the additional `$responsive-extra` and `$desk-wide-push`
+ * variables to ‘true’ in `_vars.scss` then you now have access to the
+ * following class available to accomodate much larger screen resolutions.
+ */
+
+@if $responsive-extra == true and $desk-wide-push == true{
+
+@include media-query(desk-wide){
+    @include push-setup("desk-wide-");
+}
+
+}
+
 }//endif


### PR DESCRIPTION
The `push` and `pull` CSS classes was also available as modifiers for the specific media queries (e.g.: `pull--portable-one-eighth`), except for the `desk-wide` media query.

This PR adds the `push` and `pull` for all the media queries.
