### PR TITLE
Adjust notation to work with libsass

### DIFF
--- a/base/_code.scss
+++ b/base/_code.scss
@@ -25,7 +25,6 @@ pre{
      * Override this setting in your theme stylesheet
      */
     opacity:0.75;
-    filter:alpha(opacity=75);
 }
 
 

--- a/generic/_helper.scss
+++ b/generic/_helper.scss
@@ -120,7 +120,6 @@
  */
 .muted{
     opacity:0.5!important;
-    filter:alpha(opacity = 50)!important;
 }
 
 

--- a/generic/_mixins.scss
+++ b/generic/_mixins.scss
@@ -74,24 +74,24 @@
  *
  * Courtesy of @integralist: twitter.com/integralist/status/260484115315437569
  */
-@mixin keyframe ($animation-name){
-    @-webkit-keyframes $animation-name{
+@mixin keyframe($animation-name){
+    @-webkit-keyframes #{$animation-name}{
         @content;
     }
 
-    @-moz-keyframes $animation-name{
+    @-moz-keyframes #{$animation-name}{
         @content;
     }
 
-    @-ms-keyframes $animation-name{
+    @-ms-keyframes #{$animation-name}{
         @content;
     }
 
-    @-o-keyframes $animation-name{
+    @-o-keyframes #{$animation-name}{
         @content;
     }
 
-    @keyframes $animation-name{
+    @keyframes #{$animation-name}{
         @content;
     }
 }


### PR DESCRIPTION
This includes the fix provided in #261

Compatibility with libsass is relevant, because it removes the Ruby dependency for Sass (https://github.com/hcatlin/libsass).
