### PR TITLE
Fix issue that prevents gulp-sass compilation

### DIFF
--- a/generic/_mixins.scss
+++ b/generic/_mixins.scss
@@ -77,23 +77,23 @@
  * Courtesy of @integralist: twitter.com/integralist/status/260484115315437569
  */
 @mixin keyframe ($animation-name){
-    @-webkit-keyframes $animation-name{
+    @-webkit-keyframes #{$animation-name}{
         @content;
     }
 
-    @-moz-keyframes $animation-name{
+    @-moz-keyframes #{$animation-name}{
         @content;
     }
 
-    @-ms-keyframes $animation-name{
+    @-ms-keyframes #{$animation-name}{
         @content;
     }
 
-    @-o-keyframes $animation-name{
+    @-o-keyframes #{$animation-name}{
         @content;
     }
 
-    @keyframes $animation-name{
+    @keyframes #{$animation-name}{
         @content;
     }
 }


### PR DESCRIPTION
When compiling inuit with gulp-sass, it errors with: 
`non-terminal statement or declaration must end with ;`

The variables just need to be interpolated properly.

N.B. The 'inuit.css' folder also needs the dot removing to behave with gulp-sass.
