### PR TITLE
Image source of inuitcss logo changed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![inuit.css](http://inuitcss.com/img/content/logo.png)
+![inuit.css](http://inuitcss.com/img/logo.png)
 
 # inuit.css – v5.0
 


### PR DESCRIPTION
It appears to be hosted on the following address: http://inuitcss.com/img/logo.png.
