### PR TITLE
Globals are unsuported in libsass, disable english quotes until libsass is updated

### DIFF
--- a/_defaults.scss
+++ b/_defaults.scss
@@ -138,7 +138,7 @@ $micro-size:        10px!default;
 /**
  * English quote marks?
  */
-$english-quotes:    true!default;
+$english-quotes:    false!default;
 
 /**
  * If you want English quotes then please do not edit these; they’re only here

--- a/base/_quotes.scss
+++ b/base/_quotes.scss
@@ -4,10 +4,11 @@
 /**
  * If English quotes are set in `_vars.scss`, define them here.
  */
-@if $english-quotes == true{
-    $open-quote:    \201C !global;
-    $close-quote:   \201D !global;
-}
+// Globals are unsuported in libsass, disable until libsass is updated - https://github.com/sass/libsass/issues/278, https://github.com/ptim/inuit.css/commit/89b0b2cc6b1ec74b7756e9f90577b14f2ad49fa2, https://github.com/Shandem/ClientDependency/issues/12
+//@if $english-quotes == true{
+//    $open-quote:    \201C !global;
+//    $close-quote:   \201D !global;
+//}
 
 
 /**


### PR DESCRIPTION
This adresses using InuitCSS with `libsass` instead of the normal Ruby version. 

I know that InuitCSS is growing up into it's own account and repo, but this is becoming a problem on existing problems, using this older repo.

_OFF-TOPIC:_ The new InuitCSS repo's hard dependency on bower makes it close to unusable for me. Sad, as I really liked working with it. 
